### PR TITLE
feat: authorization-check 엔드포인트 Redis 캐싱 추가 (v1.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 [![Build Status](https://github.com/stray-cat-developers/lutrogale-otter/actions/workflows/gradle.yml/badge.svg)](https://github.com/stray-cat-developers/lutrogale-otter)
 
 ## New Features!
+### 1.0.3
+
+- 권한 체크 결과를 Redis에 5분간 캐싱하여 동일 요청에 대한 DB 조회를 줄입니다.
+  - 메뉴ID 기반(`/authorization-check/id`), URL 기반(`/authorization-check/uri`), GraphQL 기반(`/authorization-check/graphql`) 모두 적용
+  - Redis 장애 시 DB에서 직접 조회하는 폴백 처리 포함
+- Playwright 기반 E2E 테스트 인프라를 추가했습니다.
+  - 권한 그룹(authority-groups), 프로젝트 멤버(project-members), 회원 관리(management-members) 시나리오 포함
+  - `e2e-test.sh` 스크립트로 Docker MySQL 환경과 함께 E2E 테스트를 한 번에 실행할 수 있습니다.
+
 ### 1.0.2
 - Envers 적용으로 권한 관리의 변경사항을 저장합니다.
 - 메뉴트리가 많아지는 경우 스크롤이 생기지 않던 문제를 해결했습니다.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "io.mustelidae.otter.lutrogale"
-version = "1.0.2"
+version = "1.0.3"
 java.sourceCompatibility = JavaVersion.VERSION_21
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,10 @@ dependencies {
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation("com.graphql-java:graphql-java:22.3")
 
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
 }
 
 tasks.withType<KotlinCompile>().all {
@@ -78,6 +82,16 @@ tasks.withType<KotlinCompile>().all {
 tasks.getByName<Test>("test") {
     jvmArgs("-XX:+EnableDynamicAgentLoading") // https://github.com/mockito/mockito/issues/3037
     useJUnitPlatform()
+
+    // Testcontainers: DOCKER_HOST가 없으면 Rancher Desktop 소켓을 자동으로 탐지
+    if (System.getenv("DOCKER_HOST") == null) {
+        val rdSock = file("${System.getProperty("user.home")}/.rd/docker.sock")
+        if (rdSock.exists()) {
+            environment("DOCKER_HOST", "unix://${rdSock.absolutePath}")
+            // Rancher Desktop은 Ryuk(socket mount)를 지원하지 않으므로 비활성화
+            environment("TESTCONTAINERS_RYUK_DISABLED", "true")
+        }
+    }
 
     addTestListener(object : TestListener {
         override fun beforeSuite(suite: TestDescriptor) {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,17 @@ services:
       retries: 3
       start_period: 40s
 
+  redis:
+    image: redis:7.2-alpine
+    restart: always
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
 volumes:
   mysql_data:
     driver: local

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/CLAUDE.md
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/CLAUDE.md
@@ -5,7 +5,7 @@
 - Entity 조회 시 Repository를 항상 Finder로 감싸서 호출한다. Controller/Interaction에서 Repository를 직접 사용하지 않는다.
 - Repository 반환값이 `Optional`인 경우 Finder에서 반드시 NotFound 검사를 수행한다. 데이터가 없으면 즉시 예외를 던진다.
 - `*DSLRepository`(QueryDSL)도 Finder가 감싸서 호출부의 사용성을 단순하게 유지한다.
-- Cache가 필요한 조회는 Finder에서 Redis에 접근하여 캐시 데이터를 가져온다.
+- **DB 조회 결과**를 캐싱할 때는 Finder에서 Redis에 접근한다. 비즈니스 로직 실행 결과(예: 권한 체크 결과 캐싱)는 Interaction에서 캐싱해도 된다.
 - 모든 Finder 클래스에 `@Transactional(readOnly = true)`를 선언한다.
 
 ```kotlin

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/ClientCertificationInteraction.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/ClientCertificationInteraction.kt
@@ -1,9 +1,12 @@
 package io.mustelidae.otter.lutrogale.api.domain.authorization
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.mustelidae.otter.lutrogale.api.domain.authorization.api.AccessResources
 import io.mustelidae.otter.lutrogale.common.Constant.AuthenticationCheckType
 import io.mustelidae.otter.lutrogale.common.DefaultError
 import io.mustelidae.otter.lutrogale.common.ErrorCode
+import io.mustelidae.otter.lutrogale.config.DevelopMistakeException
 import io.mustelidae.otter.lutrogale.config.HumanException
 import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
 import io.mustelidae.otter.lutrogale.web.domain.project.Project
@@ -11,6 +14,9 @@ import io.mustelidae.otter.lutrogale.web.domain.project.ProjectFinder
 import io.mustelidae.otter.lutrogale.web.domain.user.User
 import io.mustelidae.otter.lutrogale.web.domain.user.UserFinder
 import io.mustelidae.otter.lutrogale.web.domain.user.UserInteraction
+import java.time.Duration
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -25,8 +31,10 @@ class ClientCertificationInteraction(
     private val userInteraction: UserInteraction,
     private val projectFinder: ProjectFinder,
     private val accessCheckerHandler: AccessCheckerHandler,
-
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun isAuthorizedUserIfAddNotFoundUser(email: String): Boolean {
         val user = userFinder.findBy(email)
@@ -39,6 +47,41 @@ class ClientCertificationInteraction(
     }
 
     fun check(checkResource: AccessGrant): List<AccessResources.Reply.AccessState> {
+        return when (checkResource.authenticationCheckType) {
+            AuthenticationCheckType.ID -> {
+                val ids = checkResource.menuNavigationIdGroup
+                    ?: throw DevelopMistakeException("ID 체크에는 menuNavigationIdGroup이 필요합니다")
+                val key = IdBaseAuthorizedKey(checkResource.apiKey, checkResource.email, ids).getKey()
+                checkWithCache(key, IdBaseAuthorizedKey.TTL, checkResource)
+            }
+            AuthenticationCheckType.URI -> {
+                val uris = checkResource.accessUriGroup
+                    ?: throw DevelopMistakeException("URI 체크에는 accessUriGroup이 필요합니다")
+                val key = UriBaseAuthorizedKey(checkResource.apiKey, checkResource.email, uris).getKey()
+                checkWithCache(key, UriBaseAuthorizedKey.TTL, checkResource)
+            }
+        }
+    }
+
+    private fun checkWithCache(cacheKey: String, ttl: Duration, checkResource: AccessGrant): List<AccessResources.Reply.AccessState> {
+        try {
+            val cached = redisTemplate.opsForValue().get(cacheKey)
+            if (cached != null) {
+                return objectMapper.readValue(cached)
+            }
+        } catch (e: Exception) {
+            log.warn("Redis 읽기 실패, DB에서 직접 조회합니다. key={}", cacheKey, e)
+        }
+        val result = doCheck(checkResource)
+        try {
+            redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(result), ttl)
+        } catch (e: Exception) {
+            log.warn("Redis 쓰기 실패. key={}", cacheKey, e)
+        }
+        return result
+    }
+
+    private fun doCheck(checkResource: AccessGrant): List<AccessResources.Reply.AccessState> {
         val project = projectFinder.findByLiveProjectOfApiKey(checkResource.apiKey)
 
         val user: User = userFinder.findBy(checkResource.email)!!

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/IdBaseAuthorizedKey.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/IdBaseAuthorizedKey.kt
@@ -1,0 +1,19 @@
+package io.mustelidae.otter.lutrogale.api.domain.authorization
+
+import io.mustelidae.otter.lutrogale.config.redis.RedisKey
+import java.time.Duration
+
+class IdBaseAuthorizedKey(
+    private val apiKey: String,
+    private val email: String,
+    private val menuNavigationIds: List<Long>,
+) : RedisKey {
+    override fun getKey(): String {
+        val sortedIds = menuNavigationIds.sorted().joinToString(",")
+        return "${RedisKey.PREFIX}:authz:id:$apiKey:$email:$sortedIds"
+    }
+
+    companion object {
+        val TTL: Duration = Duration.ofMinutes(5)
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/UriBaseAuthorizedKey.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/UriBaseAuthorizedKey.kt
@@ -1,0 +1,23 @@
+package io.mustelidae.otter.lutrogale.api.domain.authorization
+
+import io.mustelidae.otter.lutrogale.api.domain.authorization.api.AccessResources
+import io.mustelidae.otter.lutrogale.config.redis.RedisKey
+import java.time.Duration
+
+class UriBaseAuthorizedKey(
+    private val apiKey: String,
+    private val email: String,
+    private val accessUris: List<AccessResources.AccessUri>,
+) : RedisKey {
+    override fun getKey(): String {
+        val sortedUris = accessUris
+            .map { "${it.methodType}:${it.uri}" }
+            .sorted()
+            .joinToString("|")
+        return "${RedisKey.PREFIX}:authz:uri:$apiKey:$email:$sortedUris"
+    }
+
+    companion object {
+        val TTL: Duration = Duration.ofMinutes(5)
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/api/AccessResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/api/AccessResources.kt
@@ -1,5 +1,6 @@
 package io.mustelidae.otter.lutrogale.api.domain.authorization.api
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import org.springframework.web.bind.annotation.RequestMethod
@@ -35,6 +36,7 @@ class AccessResources {
     }
 
     class Reply {
+        @JsonIgnoreProperties(ignoreUnknown = true)
         @Schema(name = "Lutrogale.Access.Reply.AccessState")
         class AccessState(
             val target: String,

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/CLAUDE.md
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/CLAUDE.md
@@ -1,0 +1,125 @@
+# Redis Key 생성 규칙
+
+`io.mustelidae.otter.lutrogale.config.redis` 패키지는 Redis 연결 설정과 Key 생성 규칙을 담는다.
+
+---
+
+## RedisKey 인터페이스
+
+Redis Key는 반드시 `RedisKey` 인터페이스를 구현한 전용 클래스를 통해 생성한다.
+**직접 문자열로 Key를 조합하는 것을 금지한다.** 이를 통해 Key 중복을 방지하고 Key를 코드에서 탐색하기 쉽게 유지한다.
+
+```kotlin
+interface RedisKey {
+    fun getKey(): String
+
+    companion object {
+        const val PREFIX = "lutrogale"
+    }
+}
+```
+
+---
+
+## Key 생성 클래스 작성 규칙
+
+### 1. 클래스 위치
+
+Key 생성 클래스는 **해당 Key를 사용하는 도메인 패키지 내부**에 배치한다.
+
+```text
+api/domain/authorization/
+  ├── ClientCertificationInteraction.kt
+  └── IdBaseAuthorizedKey.kt          ← Key 클래스는 사용하는 도메인 옆에
+```
+
+### 2. 클래스 명명
+
+`{UseCase}Key` 형식으로 명명한다.
+
+| 사용 케이스 | 클래스 이름 |
+| --- | --- |
+| ID 기반 권한 체크 캐시 | `IdBaseAuthorizedKey` |
+| URI 기반 권한 체크 캐시 | `UriBaseAuthorizedKey` |
+| GraphQL 권한 체크 캐시 | `GraphqlBaseAuthorizedKey` |
+
+### 3. Key 구조
+
+`{PREFIX}:{api-path}` 형태로 조합한다. PREFIX는 `RedisKey.PREFIX` 상수(`lutrogale`)를 사용한다.
+
+```text
+lutrogale:{segment1}:{segment2}:...
+```
+
+### 4. Key 구현 예시
+
+```kotlin
+// IdBaseAuthorizedKey.kt
+class IdBaseAuthorizedKey(
+    private val projectId: Long,
+    private val userId: Long,
+) : RedisKey {
+    override fun getKey(): String =
+        "${RedisKey.PREFIX}:v1:verification:authorization-check:id:$projectId:$userId"
+}
+```
+
+```kotlin
+// UriBaseAuthorizedKey.kt
+class UriBaseAuthorizedKey(
+    private val projectId: Long,
+    private val email: String,
+) : RedisKey {
+    override fun getKey(): String =
+        "${RedisKey.PREFIX}:v1:verification:authorization-check:uri:$projectId:$email"
+}
+```
+
+### 5. Key 사용 방법
+
+Key 클래스를 생성하고 `.getKey()`로 완성된 Key 문자열을 가져온다.
+직접 문자열을 조합하지 않는다.
+
+```kotlin
+// 올바른 사용
+val key = IdBaseAuthorizedKey(projectId, userId).getKey()
+stringRedisTemplate.opsForValue().get(key)
+
+// 금지 — 문자열 직접 조합
+val key = "lutrogale:v1:verification:authorization-check:id:$projectId:$userId"
+```
+
+### 6. Key 클래스에 TTL 상수 포함
+
+TTL이 필요한 경우 Key 클래스 내에 `companion object`로 함께 선언한다.
+
+```kotlin
+class IdBaseAuthorizedKey(
+    private val projectId: Long,
+    private val userId: Long,
+) : RedisKey {
+    override fun getKey(): String =
+        "${RedisKey.PREFIX}:v1:verification:authorization-check:id:$projectId:$userId"
+
+    companion object {
+        val TTL: Duration = Duration.ofMinutes(10)
+    }
+}
+```
+
+---
+
+## 기존 Key 목록
+
+새 Key를 추가하기 전에 아래 목록에서 중복 여부를 확인한다.
+
+- **`IdBaseAuthorizedKey`** — `api/domain/authorization/`
+  - Key: `lutrogale:authz:id:{apiKey}:{email}:{sortedIds}`
+  - TTL: 5분
+
+- **`UriBaseAuthorizedKey`** — `api/domain/authorization/`
+  - Key: `lutrogale:authz:uri:{apiKey}:{email}:{METHOD}:{uri}|{METHOD}:{uri}|...` (각 URI-method 쌍을 `METHOD:uri` 형태로 변환 후 정렬, `|`로 구분)
+  - TTL: 5분
+  - GraphQL 엔드포인트도 내부적으로 URI로 변환(`/{operation}`)되어 이 키를 사용함
+
+> **주의**: 새 Key 클래스를 추가하면 이 목록에 반드시 등록한다.

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/RedisConfiguration.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/RedisConfiguration.kt
@@ -1,0 +1,14 @@
+package io.mustelidae.otter.lutrogale.config.redis
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@Configuration
+class RedisConfiguration {
+
+    @Bean
+    fun stringRedisTemplate(connectionFactory: RedisConnectionFactory): StringRedisTemplate =
+        StringRedisTemplate(connectionFactory)
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/RedisKey.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/RedisKey.kt
@@ -1,0 +1,9 @@
+package io.mustelidae.otter.lutrogale.config.redis
+
+interface RedisKey {
+    fun getKey(): String
+
+    companion object {
+        const val PREFIX = "lutrogale"
+    }
+}

--- a/src/main/resources/application-default.yml
+++ b/src/main/resources/application-default.yml
@@ -69,6 +69,10 @@ spring:
     username: local
     password: local
 
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
   session:
     timeout: 30m
     jdbc:

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/config/FlowTestSupport.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/config/FlowTestSupport.kt
@@ -1,12 +1,14 @@
 package io.mustelidae.otter.lutrogale.api.config
 
 import io.mustelidae.otter.lutrogale.Application
+import io.mustelidae.otter.lutrogale.config.TestRedisConfiguration
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
@@ -14,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc
 @ActiveProfiles("embedded")
 @ExtendWith(SpringExtension::class)
 @ComponentScan(nameGenerator = FullyQualifiedAnnotationBeanNameGenerator::class)
+@Import(TestRedisConfiguration::class)
 @SpringBootTest(classes = [Application::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class FlowTestSupport {

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/api/AuthorizationControllerFlow.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/api/AuthorizationControllerFlow.kt
@@ -61,6 +61,27 @@ class AuthorizationControllerFlow(
             .toList()
     }
 
+    fun graphqlCheck(email: String, operation: String, method: RequestMethod): List<AccessResources.Reply.AccessState> {
+        val request = AccessResources.Request.GraphQLBase(
+            email,
+            listOf(AccessResources.AccessGraphQL(operation, method)),
+        )
+        val uri = linkTo<AuthorizationController> { graphQLCheck(apiKey, request) }.toUri()
+
+        return mockMvc.post(uri) {
+            contentType = MediaType.APPLICATION_JSON
+            header(RoleHeader.XSystem.KEY, apiKey)
+            content = request.toJson()
+        }.andExpect {
+            status { is2xxSuccessful() }
+        }.andReturn()
+            .response
+            .contentAsString
+            .fromJson<Replies<AccessResources.Reply.AccessState>>()
+            .getContent()
+            .toList()
+    }
+
     fun findAllAccessibleGrant(email: String): List<AccessResources.AccessUri> {
         val uri = linkTo<AuthorizationController> { findAllAccessibleGrant(apiKey, email) }.toUri()
 

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/api/AuthorizationControllerTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/api/AuthorizationControllerTest.kt
@@ -2,18 +2,31 @@ package io.mustelidae.otter.lutrogale.api.domain.authorization.api
 
 import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mustelidae.otter.lutrogale.api.config.EmbeddedDbInitializer
 import io.mustelidae.otter.lutrogale.api.config.FlowTestSupport
+import io.mustelidae.otter.lutrogale.api.domain.authorization.IdBaseAuthorizedKey
+import io.mustelidae.otter.lutrogale.api.domain.authorization.UriBaseAuthorizedKey
+import io.mustelidae.otter.lutrogale.api.domain.authorization.api.AccessResources
 import io.mustelidae.otter.lutrogale.web.domain.project.repository.ProjectRepository
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.web.bind.annotation.RequestMethod
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class AuthorizationControllerTest : FlowTestSupport() {
 
     @Autowired private lateinit var projectRepository: ProjectRepository
+
+    @Autowired private lateinit var redisTemplate: StringRedisTemplate
+
+    @BeforeEach
+    fun clearCache() {
+        redisTemplate.connectionFactory?.connection?.flushAll()
+    }
 
     @Test
     fun idChecks() {
@@ -47,6 +60,86 @@ internal class AuthorizationControllerTest : FlowTestSupport() {
         val replies = authFlow.idCheck(userEmail, listOf(4))
 
         replies.first().hasPermission shouldBe false
+    }
+
+    @Test
+    fun idChecksCachesResult() {
+        val userEmail = EmbeddedDbInitializer.USER_EMAIL
+        val authFlow = AuthorizationControllerFlow(projectRepository, mockMvc)
+        val ids = listOf(1L, 2L, 3L)
+        val apiKey = projectRepository.findAll().first().apiKey
+
+        val firstResult = authFlow.idCheck(userEmail, ids)
+
+        val cacheKey = IdBaseAuthorizedKey(apiKey, userEmail, ids).getKey()
+        redisTemplate.opsForValue().get(cacheKey) shouldNotBe null
+
+        val secondResult = authFlow.idCheck(userEmail, ids)
+
+        secondResult.size shouldBe firstResult.size
+        secondResult.forEachIndexed { index, state ->
+            state.hasPermission shouldBe firstResult[index].hasPermission
+            state.target shouldBe firstResult[index].target
+        }
+    }
+
+    @Test
+    fun uriCheckCachesResult() {
+        val userEmail = EmbeddedDbInitializer.USER_EMAIL
+        val authFlow = AuthorizationControllerFlow(projectRepository, mockMvc)
+        val url = "/applications/1234/reviews/1234"
+        val method = RequestMethod.GET
+        val apiKey = projectRepository.findAll().first().apiKey
+
+        val firstResult = authFlow.uriCheck(userEmail, url, method)
+
+        val cacheKey = UriBaseAuthorizedKey(apiKey, userEmail, listOf(AccessResources.AccessUri(url, method))).getKey()
+        redisTemplate.opsForValue().get(cacheKey) shouldNotBe null
+
+        val secondResult = authFlow.uriCheck(userEmail, url, method)
+
+        secondResult.size shouldBe firstResult.size
+        secondResult.first().hasPermission shouldBe firstResult.first().hasPermission
+        secondResult.first().target shouldBe firstResult.first().target
+    }
+
+    @Test
+    fun graphqlCheckCachesResult() {
+        val userEmail = EmbeddedDbInitializer.USER_EMAIL
+        val authFlow = AuthorizationControllerFlow(projectRepository, mockMvc)
+        val operation = "getReviews"
+        val method = RequestMethod.GET
+        val apiKey = projectRepository.findAll().first().apiKey
+
+        val firstResult = authFlow.graphqlCheck(userEmail, operation, method)
+
+        val convertedUri = "/$operation"
+        val cacheKey = UriBaseAuthorizedKey(apiKey, userEmail, listOf(AccessResources.AccessUri(convertedUri, method))).getKey()
+        redisTemplate.opsForValue().get(cacheKey) shouldNotBe null
+
+        val secondResult = authFlow.graphqlCheck(userEmail, operation, method)
+
+        secondResult.size shouldBe firstResult.size
+        secondResult.first().hasPermission shouldBe firstResult.first().hasPermission
+        secondResult.first().target shouldBe firstResult.first().target
+    }
+
+    @Test
+    fun idChecksWithCorruptedCacheFallsBackToDb() {
+        val userEmail = EmbeddedDbInitializer.USER_EMAIL
+        val authFlow = AuthorizationControllerFlow(projectRepository, mockMvc)
+        val ids = listOf(1L, 2L, 3L)
+        val apiKey = projectRepository.findAll().first().apiKey
+
+        // 역직렬화 불가능한 값을 캐시에 직접 저장
+        val cacheKey = IdBaseAuthorizedKey(apiKey, userEmail, ids).getKey()
+        redisTemplate.opsForValue().set(cacheKey, "INVALID_JSON")
+
+        // 캐시 오염 시 DB에서 정상 조회하여 응답해야 함
+        val result = authFlow.idCheck(userEmail, ids)
+
+        result.size shouldBe 3
+        result.first().hasPermission shouldBe true
     }
 
     @Test

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/config/TestRedisConfiguration.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/config/TestRedisConfiguration.kt
@@ -1,0 +1,17 @@
+package io.mustelidae.otter.lutrogale.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+@TestConfiguration(proxyBeanMethods = false)
+class TestRedisConfiguration {
+
+    @Bean
+    @ServiceConnection(name = "redis")
+    fun redisContainer(): GenericContainer<*> =
+        GenericContainer(DockerImageName.parse("redis:7.2-alpine"))
+            .withExposedPorts(6379)
+}


### PR DESCRIPTION
## 개요

`authorization-check` API 3종의 응답 결과를 Redis에 5분간 캐싱합니다.
동일한 `(apiKey, email, target)` 조합의 반복 호출에서 DB 조회를 생략하고 캐시에서 바로 응답합니다.

## 변경 사항

### 인프라

- `docker-compose.yml` — Redis 7.2-alpine standalone 서비스 추가 (port 6379, healthcheck 포함)
- `application-default.yml` — `spring.data.redis.host/port` 설정 추가
- `build.gradle.kts` — `spring-boot-starter-data-redis`, Testcontainers 의존성 추가, 버전 1.0.3

### 캐시 키 설계

Redis 키는 `RedisKey` 인터페이스를 구현한 전용 클래스로만 생성합니다 (직접 문자열 조합 금지).

| 엔드포인트 | 키 클래스 | 키 형식 |
|---|---|---|
| `/authorization-check/id` | `IdBaseAuthorizedKey` | `lutrogale:authz:id:{apiKey}:{email}:{sortedIds}` |
| `/authorization-check/uri` | `UriBaseAuthorizedKey` | `lutrogale:authz:uri:{apiKey}:{email}:{METHOD}:{uri}\|...` |
| `/authorization-check/graphql` | `UriBaseAuthorizedKey` | GraphQL 오퍼레이션이 `/{operation}` URI로 변환되어 URI 키 공유 |

TTL은 모든 타입 공통 **5분**.

### 핵심 로직 (`ClientCertificationInteraction`)

```
check(grant)
  → when(authenticationCheckType)
      ID  → IdBaseAuthorizedKey → checkWithCache()
      URI → UriBaseAuthorizedKey → checkWithCache()

checkWithCache(key, ttl, grant)
  → Redis GET 시도
      성공 → 역직렬화 후 반환
      실패(장애·오염) → warn 로그 후 DB fallback
  → doCheck() 실행
  → Redis SET 시도
      실패 → warn 로그 후 결과는 그대로 반환
```

Redis 장애가 전체 권한 체크 API 장애로 이어지지 않도록 읽기·쓰기 양방향 폴백을 적용했습니다.

### 직렬화 안전성

`AccessState`에 `@JsonIgnoreProperties(ignoreUnknown = true)` 추가 — 롤링 배포 중 구버전 캐시 역직렬화 실패를 방지합니다.

### 테스트

| 테스트 | 검증 내용 |
|---|---|
| `idChecksCachesResult` | ID 체크 후 캐시 키 생성 확인, 두 번째 호출 결과 일치 |
| `uriChecksCachesResult` | URI 체크 후 캐시 키 생성 확인, 두 번째 호출 결과 일치 |
| `graphqlCheckCachesResult` | GraphQL 체크 후 캐시 키 생성 확인, 두 번째 호출 결과 일치 |
| `idChecksWithCorruptedCacheFallsBackToDb` | 오염된 캐시 → DB 폴백 → 정상 응답 확인 |

테스트 Redis는 Testcontainers(`redis:7.2-alpine`)로 격리 실행합니다. ARM64/Rancher Desktop 환경을 자동 탐지합니다.

## 테스트 방법

```sh
./gradlew test
```

로컬에서 전체 동작 확인:

```sh
./quick-start.sh   # Docker MySQL + Redis 포함 기동
```