### PR TITLE
feat: admin account management — list, create, expire, password change

### DIFF
--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/DbInitializer.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/DbInitializer.kt
@@ -2,6 +2,7 @@ package io.mustelidae.otter.lutrogale
 
 import io.mustelidae.otter.lutrogale.common.Constant
 import io.mustelidae.otter.lutrogale.web.domain.admin.Admin
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
 import io.mustelidae.otter.lutrogale.web.domain.admin.repository.AdminRepository
 import io.mustelidae.otter.lutrogale.web.domain.authority.api.AuthorityBundleResources
 import io.mustelidae.otter.lutrogale.web.domain.authority.api.AuthorityController
@@ -140,15 +141,14 @@ class DbInitializer(
         val supervisor = adminRepository.findByIdOrNull(1)
 
         if (supervisor == null) {
-            val admin = Admin(
+            val admin = Admin.of(
                 "admin@osori.com",
+                "admin",
                 "슈퍼 관리자",
                 "오소리의 모든 권한을 가지고 있습니다.",
                 "/static/dist/img/osori.png",
-            ).apply {
-                setPassword("admin")
-                status = true
-            }
+                AdminRole.SUPER,
+            )
             adminRepository.save(admin)
         }
     }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/WebConfiguration.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/WebConfiguration.kt
@@ -83,6 +83,7 @@ class WebConfiguration(
         registry.addViewController("/")
             .setViewName("forward:/dashboard")
 
+        registry.addViewController("/view/management/admins").setViewName("management/admin/admins")
         registry.addViewController("/view/management/members").setViewName("management/member/members")
         registry.addViewController("/view/management/new-member").setViewName("management/member/new-member")
         registry.addViewController("/view/management/new-member/{userId}/authority-grant")

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/Admin.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/Admin.kt
@@ -1,9 +1,12 @@
 package io.mustelidae.otter.lutrogale.web.domain.admin
 
+import io.mustelidae.otter.lutrogale.common.Audit
 import io.mustelidae.otter.lutrogale.utils.Crypto
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -11,11 +14,11 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
-import java.util.ArrayList
+import org.hibernate.annotations.SQLRestriction
+import org.hibernate.envers.Audited
+import org.hibernate.envers.RelationTargetAuditMode
 
-/**
- * Created by HanJaehyun on 2016. 9. 20..
- */
+@Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
 @Entity
 class Admin(
     @Column(unique = true, nullable = false)
@@ -23,7 +26,7 @@ class Admin(
     val name: String,
     var description: String? = null,
     var img: String? = null,
-) {
+) : Audit() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
@@ -33,18 +36,27 @@ class Admin(
     var pw: String? = null
         private set
 
-    var status = false
+    var status = true
+        private set
+
+    @Column(nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    var role: AdminRole = AdminRole.REGULAR
+        private set
 
     @ManyToOne
     @JoinColumn(name = "parentId")
-    private var parentAdmin: Admin? = null
+    var parentAdmin: Admin? = null
+        private set
 
+    @SQLRestriction("status = true")
     @OneToMany(
         mappedBy = "parentAdmin",
         fetch = FetchType.LAZY,
         cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH],
     )
-    private val admins: MutableList<Admin> = ArrayList()
+    val admins: MutableList<Admin> = ArrayList()
+
     fun setBy(parentAdmin: Admin) {
         this.parentAdmin = parentAdmin
         if (!parentAdmin.admins.contains(this)) parentAdmin.addBy(this)
@@ -59,15 +71,15 @@ class Admin(
         this.pw = Crypto.sha256(pw)
     }
 
+    fun expire() {
+        status = false
+    }
+
     companion object {
-        fun of(email: String, pw: String, name: String, description: String?, img: String?): Admin {
-            return Admin(
-                email,
-                name,
-                description,
-                img,
-            ).apply {
+        fun of(email: String, pw: String, name: String, description: String?, img: String?, role: AdminRole = AdminRole.REGULAR): Admin {
+            return Admin(email, name, description, img).apply {
                 setPassword(pw)
+                this.role = role
             }
         }
     }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminFinder.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminFinder.kt
@@ -4,6 +4,7 @@ import io.mustelidae.otter.lutrogale.common.DefaultError
 import io.mustelidae.otter.lutrogale.common.ErrorCode
 import io.mustelidae.otter.lutrogale.config.DataNotFindException
 import io.mustelidae.otter.lutrogale.config.PolicyException
+import io.mustelidae.otter.lutrogale.web.domain.admin.repository.AdminDSLRepository
 import io.mustelidae.otter.lutrogale.web.domain.admin.repository.AdminRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -13,14 +14,16 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class AdminFinder(
     private val adminRepository: AdminRepository,
+    private val adminDSLRepository: AdminDSLRepository,
 ) {
 
     fun findBy(id: Long): Admin {
         val admin = adminRepository.findByIdOrNull(id) ?: throw DataNotFindException("어드민 정보가 존재하지 않습니다.")
         if (!admin.status) {
-            throw throw PolicyException(DefaultError(ErrorCode.PL02, "해당 사용자는 로그인 권한이 만료되었습니다."))
+            throw PolicyException(DefaultError(ErrorCode.PL02, "해당 사용자는 로그인 권한이 만료되었습니다."))
         }
-
         return admin
     }
+
+    fun findAllActive(): List<Admin> = adminDSLRepository.findAllActive()
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminInteraction.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminInteraction.kt
@@ -1,5 +1,9 @@
 package io.mustelidae.otter.lutrogale.web.domain.admin
 
+import io.mustelidae.otter.lutrogale.common.DefaultError
+import io.mustelidae.otter.lutrogale.common.ErrorCode
+import io.mustelidae.otter.lutrogale.config.PermissionException
+import io.mustelidae.otter.lutrogale.config.PolicyException
 import io.mustelidae.otter.lutrogale.web.domain.admin.repository.AdminRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,13 +18,7 @@ class AdminInteraction(
     private val adminFinder: AdminFinder,
 ) {
     fun register(email: String, pw: String, name: String, description: String?, img: String?): Admin {
-        val admin = Admin.of(
-            email,
-            pw,
-            name,
-            description,
-            img,
-        )
+        val admin = Admin.of(email, pw, name, description, img)
         return adminRepository.save(admin)
     }
 
@@ -36,6 +34,33 @@ class AdminInteraction(
             admin.setPassword(pw!!)
         }
 
+        adminRepository.save(admin)
+    }
+
+    fun registerBy(email: String, pw: String, name: String, description: String?, img: String?, role: AdminRole, parentAdminId: Long?): Long {
+        val admin = Admin.of(email, pw, name, description, img, role)
+        if (parentAdminId != null) {
+            val parentAdmin = adminFinder.findBy(parentAdminId)
+            admin.setBy(parentAdmin)
+        }
+        return adminRepository.save(admin).id!!
+    }
+
+    fun expireBy(adminId: Long, requestingAdminId: Long) {
+        if (adminId == requestingAdminId) {
+            throw PolicyException(DefaultError(ErrorCode.PL02, "본인 계정은 만료할 수 없습니다."))
+        }
+        val admin = adminFinder.findBy(adminId)
+        admin.expire()
+        adminRepository.save(admin)
+    }
+
+    fun changePasswordBy(targetAdminId: Long, requestingAdminId: Long, callerRole: AdminRole, newPw: String) {
+        if (callerRole == AdminRole.REGULAR && targetAdminId != requestingAdminId) {
+            throw PermissionException("본인 계정의 비밀번호만 변경할 수 있습니다.")
+        }
+        val admin = adminFinder.findBy(targetAdminId)
+        admin.setPassword(newPw)
         adminRepository.save(admin)
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminRole.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminRole.kt
@@ -1,0 +1,3 @@
+package io.mustelidae.otter.lutrogale.web.domain.admin
+
+enum class AdminRole { SUPER, REGULAR }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminController.kt
@@ -38,7 +38,7 @@ class AdminController(
         @RequestBody modify: AdminResources.Modify,
     ): Reply<Unit> {
         val sessionInfo = AdminSession(httpSession).infoOrThrow()
-        adminInteraction.modifyBy(sessionInfo.adminId, modify.imageUrl, modify.description, modify.pw!!)
+        adminInteraction.modifyBy(sessionInfo.adminId, modify.imageUrl, modify.description, modify.pw)
         return Unit.toReply()
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminManagementController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminManagementController.kt
@@ -1,0 +1,56 @@
+package io.mustelidae.otter.lutrogale.web.domain.admin.api
+
+import io.mustelidae.otter.lutrogale.common.Reply
+import io.mustelidae.otter.lutrogale.common.toReply
+import io.mustelidae.otter.lutrogale.config.PermissionException
+import io.mustelidae.otter.lutrogale.web.AdminSession
+import io.mustelidae.otter.lutrogale.web.common.annotation.LoginCheck
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminFinder
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminInteraction
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpSession
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "어드민 관리")
+@LoginCheck
+@RestController
+@RequestMapping("/v1/maintenance/management/admin")
+class AdminManagementController(
+    private val adminInteraction: AdminInteraction,
+    private val adminFinder: AdminFinder,
+    private val httpSession: HttpSession,
+) {
+    @Operation(summary = "어드민 만료 (SUPER 전용)")
+    @PostMapping("/{adminId}/expire")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun expire(@PathVariable adminId: Long): Reply<Unit> {
+        val sessionInfo = AdminSession(httpSession).infoOrThrow()
+        val caller = adminFinder.findBy(sessionInfo.adminId)
+        if (caller.role != AdminRole.SUPER) {
+            throw PermissionException("어드민 만료는 SUPER 권한만 가능합니다.")
+        }
+        adminInteraction.expireBy(adminId, sessionInfo.adminId)
+        return Unit.toReply()
+    }
+
+    @Operation(summary = "비밀번호 변경 (SUPER: 모든 어드민, REGULAR: 본인만)")
+    @PutMapping("/{adminId}/pw")
+    fun changePassword(
+        @PathVariable adminId: Long,
+        @RequestBody request: AdminResources.Request.PasswordChange,
+    ): Reply<Unit> {
+        val sessionInfo = AdminSession(httpSession).infoOrThrow()
+        val caller = adminFinder.findBy(sessionInfo.adminId)
+        adminInteraction.changePasswordBy(adminId, sessionInfo.adminId, caller.role, request.pw)
+        return Unit.toReply()
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminResources.kt
@@ -1,7 +1,9 @@
 package io.mustelidae.otter.lutrogale.web.domain.admin.api
 
 import io.mustelidae.otter.lutrogale.web.domain.admin.Admin
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
 
 class AdminResources {
 
@@ -19,6 +21,7 @@ class AdminResources {
         val name: String,
         val description: String? = null,
         val img: String? = null,
+        val role: AdminRole,
     ) {
 
         companion object {
@@ -31,8 +34,54 @@ class AdminResources {
                         name,
                         description,
                         img,
+                        role,
                     )
                 }
+            }
+        }
+    }
+
+    class Request {
+
+        @Schema(name = "Lutrogale.Admin.Request.Create")
+        class Create(
+            val email: String,
+            val name: String,
+            val pw: String,
+            val role: AdminRole,
+            val description: String? = null,
+            val parentAdminId: Long? = null,
+        )
+
+        @Schema(name = "Lutrogale.Admin.Request.PasswordChange")
+        class PasswordChange(
+            val pw: String,
+        )
+    }
+
+    @Schema(name = "Lutrogale.Admin.AdminRow")
+    data class AdminRow(
+        val id: Long,
+        val email: String,
+        val name: String,
+        val role: AdminRole,
+        val description: String?,
+        val createdAt: LocalDateTime,
+        val parentAdminId: Long?,
+        val children: List<AdminRow>,
+    ) {
+        companion object {
+            fun from(admin: Admin): AdminRow {
+                return AdminRow(
+                    id = admin.id!!,
+                    email = admin.email,
+                    name = admin.name,
+                    role = admin.role,
+                    description = admin.description,
+                    createdAt = admin.createdAt!!,
+                    parentAdminId = admin.parentAdmin?.id,
+                    children = admin.admins.map { from(it) },
+                )
             }
         }
     }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminsController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminsController.kt
@@ -1,0 +1,61 @@
+package io.mustelidae.otter.lutrogale.web.domain.admin.api
+
+import io.mustelidae.otter.lutrogale.common.Replies
+import io.mustelidae.otter.lutrogale.common.Reply
+import io.mustelidae.otter.lutrogale.common.toReplies
+import io.mustelidae.otter.lutrogale.common.toReply
+import io.mustelidae.otter.lutrogale.config.PermissionException
+import io.mustelidae.otter.lutrogale.web.AdminSession
+import io.mustelidae.otter.lutrogale.web.common.annotation.LoginCheck
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminFinder
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminInteraction
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpSession
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "어드민 관리")
+@LoginCheck
+@RestController
+@RequestMapping("/v1/maintenance/management/admins")
+class AdminsController(
+    private val adminInteraction: AdminInteraction,
+    private val adminFinder: AdminFinder,
+    private val httpSession: HttpSession,
+) {
+    @Operation(summary = "어드민 목록 조회 (활성 어드민만)")
+    @GetMapping
+    fun findAll(): Replies<AdminResources.AdminRow> {
+        val allAdmins = adminFinder.findAllActive()
+        val rootAdmins = allAdmins.filter { it.parentAdmin == null }
+        return rootAdmins.map { AdminResources.AdminRow.from(it) }.toReplies()
+    }
+
+    @Operation(summary = "어드민 생성 (SUPER 전용)")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@RequestBody request: AdminResources.Request.Create): Reply<Long> {
+        val sessionInfo = AdminSession(httpSession).infoOrThrow()
+        val caller = adminFinder.findBy(sessionInfo.adminId)
+        if (caller.role != AdminRole.SUPER) {
+            throw PermissionException("어드민 생성은 SUPER 권한만 가능합니다.")
+        }
+        val id = adminInteraction.registerBy(
+            request.email,
+            request.pw,
+            request.name,
+            request.description,
+            null,
+            request.role,
+            request.parentAdminId,
+        )
+        return id.toReply()
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/repository/AdminDSLRepository.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/repository/AdminDSLRepository.kt
@@ -1,0 +1,19 @@
+package io.mustelidae.otter.lutrogale.web.domain.admin.repository
+
+import io.mustelidae.otter.lutrogale.web.domain.admin.Admin
+import io.mustelidae.otter.lutrogale.web.domain.admin.QAdmin.admin
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+
+@Repository
+class AdminDSLRepository : QuerydslRepositorySupport(Admin::class.java) {
+
+    fun findAllActive(): List<Admin> {
+        return from(admin)
+            .leftJoin(admin.admins).fetchJoin()
+            .leftJoin(admin.parentAdmin).fetchJoin()
+            .where(admin.status.isTrue)
+            .fetch()
+            .distinct()
+    }
+}

--- a/src/main/resources/static/dist/js/route.js
+++ b/src/main/resources/static/dist/js/route.js
@@ -16,6 +16,7 @@ var OsoriRoute = (function () {
     map.set("view.management.newMember.personalGrant",  "/view/management/new-member/{userId}/personal-grant");
     map.set("view.management.newMember.complete",       "/view/management/new-member/{userId}/complete");
 
+    map.set("view.management.admins",        "/view/management/admins");
     map.set("view.management.members",      "/view/management/members");
 
     map.set("view.project.configuration.navigation",    "/view/project/{id}/configuration/navigation");
@@ -23,8 +24,13 @@ var OsoriRoute = (function () {
     map.set("view.project.configuration.members",       "/view/project/{id}/configuration/members");
 
     //Api
-    map.set("admin.findOne",    "/v1/maintenance/management/admin");
-    map.set("admin.modifyInfo", "/v1/maintenance/management/admin");
+    map.set("admin.findOne",          "/v1/maintenance/management/admin");
+    map.set("admin.modifyInfo",       "/v1/maintenance/management/admin");
+    map.set("admin.expire",           "/v1/maintenance/management/admin/{adminId}/expire");
+    map.set("admin.changePassword",   "/v1/maintenance/management/admin/{adminId}/pw");
+
+    map.set("admins.findAll",  "/v1/maintenance/management/admins");
+    map.set("admins.create",   "/v1/maintenance/management/admins");
 
     map.set("user.create",                  "/v1/maintenance/management/user");
     map.set("user.modifyInfo",              "/v1/maintenance/management/user/{userId}");

--- a/src/main/resources/templates/layout/gnb-left.ftl
+++ b/src/main/resources/templates/layout/gnb-left.ftl
@@ -4,6 +4,11 @@
         <!-- sidebar menu: : style can be found in sidebar.less -->
         <ul class="sidebar-menu">
             <li class="header">Management<li>
+                <a id="admins" href="#" onclick="OsoriRoute.go('view.management.admins');">
+                    <i class="fa fa-user-secret"></i> <span>어드민 관리</span>
+                </a>
+            </li>
+            <li>
                 <a id="members" href="#" onclick="OsoriRoute.go('view.management.members');">
                     <i class="fa fa-users"></i> <span>사용자 정보 관리</span>
                 </a>
@@ -14,6 +19,8 @@
     <!-- /.sidebar -->
 </aside>
 <script>
+    if(window.location.pathname === OsoriRoute.getUri('view.management.admins',{}))
+        $('#admins').parents('li').addClass('active');
     if(window.location.pathname === OsoriRoute.getUri('view.management.members',{}))
         $('#members').parents('li').addClass('active');
 

--- a/src/main/resources/templates/management/admin/admins.ftl
+++ b/src/main/resources/templates/management/admin/admins.ftl
@@ -1,0 +1,203 @@
+<#import "../../mecro/base-layout.ftl" as layout>
+<!DOCTYPE html>
+<html lang="ko">
+    <@layout.baseHeader "Admins">
+    </@layout.baseHeader>
+
+    <body class="hold-transition skin-blue sidebar-mini">
+        <@layout.baseWrapper>
+        <section class="content-header">
+            <h1>어드민 관리<small>시스템 관리자 계정을 관리합니다.</small></h1>
+        </section>
+        <section class="content">
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="box box-solid">
+                        <div class="box-header">
+                            <h3 class="box-title">어드민 목록</h3>
+                            <div class="box-tools pull-right">
+                                <button id="btn-add-admin" type="button" class="btn btn-primary btn-sm" style="display:none;">
+                                    <i class="fa fa-plus"></i> 어드민 추가
+                                </button>
+                            </div>
+                        </div>
+                        <div class="box-body">
+                            <table class="table table-bordered table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>ID</th>
+                                        <th>이메일</th>
+                                        <th>이름</th>
+                                        <th>역할</th>
+                                        <th>상위 어드민</th>
+                                        <th>설명</th>
+                                        <th>생성일</th>
+                                        <th>액션</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="tb-admins-body"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <@layout.plainModal "" "modal-dialog" "modal-add-admin" "true"/>
+        <@layout.plainModal "" "modal-dialog" "modal-change-pw" "true"/>
+        </@layout.baseWrapper>
+
+        <script>
+            var currentAdminId = null;
+            var currentAdminRole = null;
+            var allAdmins = [];
+
+            $(document).ready(function() {
+                AJAX.getData(OsoriRoute.getUri('admin.findOne')).done(function(data) {
+                    currentAdminId = data.id;
+                    currentAdminRole = data.role;
+                    if (currentAdminRole === 'SUPER') {
+                        $('#btn-add-admin').show();
+                    }
+                }).always(function() {
+                    loadAdmins();
+                });
+
+                $('#btn-add-admin').click(function() {
+                    openAddAdminModal();
+                });
+
+                $('#modal-add-admin-submit').click(function() {
+                    submitAddAdmin();
+                });
+
+                $('#modal-change-pw-submit').click(function() {
+                    submitChangePw();
+                });
+            });
+
+            function loadAdmins() {
+                AJAX.getData(OsoriRoute.getUri('admins.findAll')).done(function(data) {
+                    allAdmins = data.content;
+                    renderAdminTable(allAdmins);
+                });
+            }
+
+            function renderAdminTable(admins) {
+                var tbody = $('#tb-admins-body');
+                tbody.empty();
+                $.each(admins, function(i, admin) {
+                    tbody.append(buildRow(admin, false));
+                    if (admin.children && admin.children.length > 0) {
+                        $.each(admin.children, function(j, child) {
+                            tbody.append(buildRow(child, true));
+                        });
+                    }
+                });
+            }
+
+            function buildRow(admin, isChild) {
+                var prefix = isChild ? '&nbsp;&nbsp;&nbsp;&nbsp;└&nbsp;' : '';
+                var roleBadge = admin.role === 'SUPER'
+                    ? '<span class="label label-danger">SUPER</span>'
+                    : '<span class="label label-default">REGULAR</span>';
+                var parentName = isChild ? (admin.parentAdminId || '-') : '-';
+                var createdAt = admin.createdAt ? admin.createdAt.substring(0, 10) : '-';
+                var actions = buildActions(admin);
+
+                return '<tr>' +
+                    '<td>' + admin.id + '</td>' +
+                    '<td>' + prefix + admin.email + '</td>' +
+                    '<td>' + admin.name + '</td>' +
+                    '<td>' + roleBadge + '</td>' +
+                    '<td>' + parentName + '</td>' +
+                    '<td>' + (admin.description || '') + '</td>' +
+                    '<td>' + createdAt + '</td>' +
+                    '<td>' + actions + '</td>' +
+                    '</tr>';
+            }
+
+            function buildActions(admin) {
+                var html = '';
+                if (currentAdminRole === 'SUPER' || admin.id === currentAdminId) {
+                    html += '<button class="btn btn-warning btn-xs" onclick="openChangePwModal(' + admin.id + ')">PW 변경</button> ';
+                }
+                if (currentAdminRole === 'SUPER' && admin.id !== currentAdminId) {
+                    html += '<button class="btn btn-danger btn-xs" onclick="expireAdmin(' + admin.id + ', \'' + admin.name + '\')">만료</button>';
+                }
+                return html;
+            }
+
+            function openAddAdminModal() {
+                var parentOptions = '<option value="">없음</option>';
+                $.each(allAdmins, function(i, a) {
+                    parentOptions += '<option value="' + a.id + '">' + a.name + ' (' + a.email + ')</option>';
+                });
+
+                var body =
+                    '<form role="form">' +
+                    '<div class="form-group"><label>이메일</label><input id="add-email" type="email" class="form-control" placeholder="이메일 입력"></div>' +
+                    '<div class="form-group"><label>이름</label><input id="add-name" type="text" class="form-control" placeholder="이름 입력"></div>' +
+                    '<div class="form-group"><label>비밀번호</label><input id="add-pw" type="password" class="form-control" placeholder="비밀번호 입력"></div>' +
+                    '<div class="form-group"><label>역할</label><select id="add-role" class="form-control"><option value="REGULAR">REGULAR</option><option value="SUPER">SUPER</option></select></div>' +
+                    '<div class="form-group"><label>설명</label><input id="add-description" type="text" class="form-control" placeholder="설명 (선택)"></div>' +
+                    '<div class="form-group"><label>상위 어드민</label><select id="add-parent" class="form-control">' + parentOptions + '</select></div>' +
+                    '</form>';
+
+                $('#modal-add-admin .modal-title').text('어드민 추가');
+                $('#modal-add-admin .modal-body').html(body);
+                $('#modal-add-admin').modal('show');
+            }
+
+            function submitAddAdmin() {
+                var parentVal = $('#modal-add-admin #add-parent').val();
+                var payload = {
+                    email: $('#modal-add-admin #add-email').val(),
+                    name: $('#modal-add-admin #add-name').val(),
+                    pw: $('#modal-add-admin #add-pw').val(),
+                    role: $('#modal-add-admin #add-role').val(),
+                    description: $('#modal-add-admin #add-description').val() || null,
+                    parentAdminId: parentVal ? parseInt(parentVal) : null
+                };
+                AJAX.postData(OsoriRoute.getUri('admins.create'), payload).done(function() {
+                    $('#modal-add-admin').modal('hide');
+                    loadAdmins();
+                }).fail(function(res) {
+                    alert(res.responseJSON ? res.responseJSON.message : '오류가 발생했습니다.');
+                });
+            }
+
+            function expireAdmin(adminId, adminName) {
+                if (!confirm('[' + adminName + '] 어드민을 만료 처리하시겠습니까?\n이 작업은 되돌릴 수 없습니다.')) return;
+                AJAX.postData(OsoriRoute.getUri('admin.expire', {adminId: adminId}), {}).done(function() {
+                    loadAdmins();
+                }).fail(function(res) {
+                    alert(res.responseJSON ? res.responseJSON.message : '오류가 발생했습니다.');
+                });
+            }
+
+            function openChangePwModal(adminId) {
+                var body =
+                    '<form role="form">' +
+                    '<input id="change-pw-target-id" type="hidden" value="' + adminId + '">' +
+                    '<div class="form-group"><label>새 비밀번호</label><input id="change-pw-new" type="password" class="form-control" placeholder="새 비밀번호 입력"></div>' +
+                    '</form>';
+
+                $('#modal-change-pw .modal-title').text('비밀번호 변경');
+                $('#modal-change-pw .modal-body').html(body);
+                $('#modal-change-pw').modal('show');
+            }
+
+            function submitChangePw() {
+                var adminId = parseInt($('#modal-change-pw #change-pw-target-id').val());
+                var payload = { pw: $('#modal-change-pw #change-pw-new').val() };
+                AJAX.putData(OsoriRoute.getUri('admin.changePassword', {adminId: adminId}), payload).done(function() {
+                    $('#modal-change-pw').modal('hide');
+                    alert('비밀번호가 변경되었습니다.');
+                }).fail(function(res) {
+                    alert(res.responseJSON ? res.responseJSON.message : '오류가 발생했습니다.');
+                });
+            }
+        </script>
+    </body>
+</html>

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/config/EmbeddedDbInitializer.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/config/EmbeddedDbInitializer.kt
@@ -2,6 +2,7 @@ package io.mustelidae.otter.lutrogale.api.config
 
 import io.mustelidae.otter.lutrogale.common.Constant
 import io.mustelidae.otter.lutrogale.web.domain.admin.Admin
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
 import io.mustelidae.otter.lutrogale.web.domain.admin.repository.AdminRepository
 import io.mustelidae.otter.lutrogale.web.domain.authority.api.AuthorityBundleResources
 import io.mustelidae.otter.lutrogale.web.domain.authority.api.AuthorityController
@@ -140,15 +141,14 @@ class EmbeddedDbInitializer(
         val supervisor = adminRepository.findByIdOrNull(1)
 
         if (supervisor == null) {
-            val admin = Admin(
+            val admin = Admin.of(
                 "admin@osori.com",
+                "admin",
                 "슈퍼 관리자",
                 "오소리의 모든 권한을 가지고 있습니다.",
                 "/static/dist/img/osori.png",
-            ).apply {
-                setPassword("admin")
-                status = true
-            }
+                AdminRole.SUPER,
+            )
             adminRepository.save(admin)
         }
     }

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/AdminTest.kt
@@ -1,0 +1,40 @@
+package io.mustelidae.otter.lutrogale.web.domain.admin
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+
+internal class AdminTest {
+
+    @Test
+    fun `Admin-of 로 생성한 어드민은 즉시 활성 상태이다`() {
+        val admin = Admin.of("test@test.com", "password", "테스트", null, null)
+        admin.status shouldBe true
+    }
+
+    @Test
+    fun `Admin-of 에 SUPER 역할을 지정하면 SUPER 어드민이 생성된다`() {
+        val admin = Admin.of("super@test.com", "password", "슈퍼", null, null, AdminRole.SUPER)
+        admin.role shouldBe AdminRole.SUPER
+    }
+
+    @Test
+    fun `Admin-of 에 역할을 지정하지 않으면 기본값 REGULAR이다`() {
+        val admin = Admin.of("regular@test.com", "password", "레귤러", null, null)
+        admin.role shouldBe AdminRole.REGULAR
+    }
+
+    @Test
+    fun `expire 호출 후 어드민은 비활성 상태이다`() {
+        val admin = Admin.of("test@test.com", "password", "테스트", null, null)
+        admin.expire()
+        admin.status shouldBe false
+    }
+
+    @Test
+    fun `setPassword 는 비밀번호를 SHA256 해시로 저장한다`() {
+        val admin = Admin.of("test@test.com", "password", "테스트", null, null)
+        admin.pw shouldNotBe null
+        admin.pw shouldNotBe "password"
+    }
+}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminManagementControllerFlow.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminManagementControllerFlow.kt
@@ -1,0 +1,80 @@
+package io.mustelidae.otter.lutrogale.web.domain.admin.api
+
+import io.mustelidae.otter.lutrogale.common.Replies
+import io.mustelidae.otter.lutrogale.common.Reply
+import io.mustelidae.otter.lutrogale.utils.fromJson
+import io.mustelidae.otter.lutrogale.utils.toJson
+import jakarta.servlet.http.Cookie
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActionsDsl
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+
+internal class AdminManagementControllerFlow(private val mockMvc: MockMvc) {
+
+    fun login(email: String, password: String): Cookie {
+        val body = mapOf("email" to email, "password" to password)
+        val response = mockMvc.post("/v1/check-login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = body.toJson()
+        }.andExpect {
+            status { is2xxSuccessful() }
+        }.andReturn().response
+
+        return response.getCookie("SESSION")
+            ?: error("SESSION cookie not found after login")
+    }
+
+    fun findAllAdmins(session: Cookie): List<AdminResources.AdminRow> {
+        return mockMvc.get("/v1/maintenance/management/admins") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+        }.andExpect {
+            status { is2xxSuccessful() }
+        }.andReturn()
+            .response
+            .contentAsString
+            .fromJson<Replies<AdminResources.AdminRow>>()
+            .getContent()
+            .toList()
+    }
+
+    fun createAdmin(session: Cookie, request: AdminResources.Request.Create): Long {
+        return mockMvc.post("/v1/maintenance/management/admins") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+            content = request.toJson()
+        }.andExpect {
+            status { isCreated() }
+        }.andReturn()
+            .response
+            .contentAsString
+            .fromJson<Reply<Long>>()
+            .content!!
+    }
+
+    fun createAdminExpectFail(session: Cookie, request: AdminResources.Request.Create): ResultActionsDsl {
+        return mockMvc.post("/v1/maintenance/management/admins") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+            content = request.toJson()
+        }
+    }
+
+    fun expireAdmin(session: Cookie, adminId: Long): ResultActionsDsl {
+        return mockMvc.post("/v1/maintenance/management/admin/$adminId/expire") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+        }
+    }
+
+    fun changePassword(session: Cookie, adminId: Long, newPw: String): ResultActionsDsl {
+        return mockMvc.put("/v1/maintenance/management/admin/$adminId/pw") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+            content = AdminResources.Request.PasswordChange(newPw).toJson()
+        }
+    }
+}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminManagementControllerTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/admin/api/AdminManagementControllerTest.kt
@@ -1,0 +1,151 @@
+package io.mustelidae.otter.lutrogale.web.domain.admin.api
+
+import io.kotest.matchers.shouldBe
+import io.mustelidae.otter.lutrogale.api.config.FlowTestSupport
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminInteraction
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
+import io.mustelidae.otter.lutrogale.web.domain.admin.repository.AdminRepository
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+internal class AdminManagementControllerTest : FlowTestSupport() {
+
+    @Autowired
+    private lateinit var adminInteraction: AdminInteraction
+
+    @Autowired
+    private lateinit var adminRepository: AdminRepository
+
+    private lateinit var flow: AdminManagementControllerFlow
+    private lateinit var superSession: Cookie
+
+    @BeforeEach
+    fun setUp() {
+        flow = AdminManagementControllerFlow(mockMvc)
+        superSession = flow.login("admin@osori.com", "admin")
+    }
+
+    @Test
+    fun `SUPER 어드민은 활성 어드민 목록을 조회할 수 있다`() {
+        val admins = flow.findAllAdmins(superSession)
+        admins.isEmpty() shouldBe false
+    }
+
+    @Test
+    fun `SUPER 어드민이 신규 어드민을 생성하면 즉시 활성 상태이다`() {
+        val request = AdminResources.Request.Create(
+            email = "new-admin@test.com",
+            name = "신규어드민",
+            pw = "password123",
+            role = AdminRole.REGULAR,
+        )
+
+        val newId = flow.createAdmin(superSession, request)
+
+        val admin = adminRepository.findById(newId).orElseThrow()
+        admin.status shouldBe true
+        admin.role shouldBe AdminRole.REGULAR
+    }
+
+    @Test
+    fun `REGULAR 어드민은 신규 어드민을 생성할 수 없다`() {
+        adminInteraction.registerBy(
+            "regular@test.com", "pw", "레귤러", null, null, AdminRole.REGULAR, null,
+        )
+        val regularSession = flow.login("regular@test.com", "pw")
+
+        val request = AdminResources.Request.Create(
+            email = "another@test.com",
+            name = "다른어드민",
+            pw = "password",
+            role = AdminRole.REGULAR,
+        )
+
+        flow.createAdminExpectFail(regularSession, request)
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `SUPER 어드민은 다른 어드민을 만료시킬 수 있다`() {
+        val targetId = adminInteraction.registerBy(
+            "expire-target@test.com", "pw", "만료대상", null, null, AdminRole.REGULAR, null,
+        )
+
+        flow.expireAdmin(superSession, targetId)
+            .andExpect { status { isCreated() } }
+
+        val expiredAdmin = adminRepository.findById(targetId).orElseThrow()
+        expiredAdmin.status shouldBe false
+    }
+
+    @Test
+    fun `SUPER 어드민은 본인 계정을 만료시킬 수 없다`() {
+        val superAdminId = adminRepository.findAll().first { it.role == AdminRole.SUPER }.id!!
+        flow.expireAdmin(superSession, superAdminId)
+            .andExpect { status { isBadRequest() } }
+    }
+
+    @Test
+    fun `REGULAR 어드민은 다른 어드민을 만료시킬 수 없다`() {
+        adminInteraction.registerBy(
+            "regular2@test.com", "pw", "레귤러2", null, null, AdminRole.REGULAR, null,
+        )
+        val targetId = adminInteraction.registerBy(
+            "target2@test.com", "pw", "만료대상2", null, null, AdminRole.REGULAR, null,
+        )
+        val regularSession = flow.login("regular2@test.com", "pw")
+
+        flow.expireAdmin(regularSession, targetId)
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `SUPER 어드민은 다른 어드민의 비밀번호를 변경할 수 있다`() {
+        val targetId = adminInteraction.registerBy(
+            "pw-change@test.com", "oldpw", "PW변경대상", null, null, AdminRole.REGULAR, null,
+        )
+
+        flow.changePassword(superSession, targetId, "newpw123")
+            .andExpect { status { isOk() } }
+    }
+
+    @Test
+    fun `REGULAR 어드민은 본인 비밀번호만 변경할 수 있다`() {
+        val regularId = adminInteraction.registerBy(
+            "self-pw@test.com", "oldpw", "본인PW변경", null, null, AdminRole.REGULAR, null,
+        )
+        val regularSession = flow.login("self-pw@test.com", "oldpw")
+
+        flow.changePassword(regularSession, regularId, "newpw456")
+            .andExpect { status { isOk() } }
+    }
+
+    @Test
+    fun `REGULAR 어드민은 타인의 비밀번호를 변경할 수 없다`() {
+        adminInteraction.registerBy(
+            "regular3@test.com", "pw", "레귤러3", null, null, AdminRole.REGULAR, null,
+        )
+        val otherAdminId = adminInteraction.registerBy(
+            "other@test.com", "pw", "다른어드민", null, null, AdminRole.REGULAR, null,
+        )
+        val regularSession = flow.login("regular3@test.com", "pw")
+
+        flow.changePassword(regularSession, otherAdminId, "hacked")
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `만료된 어드민은 목록에 포함되지 않는다`() {
+        val targetId = adminInteraction.registerBy(
+            "expired@test.com", "pw", "만료어드민", null, null, AdminRole.REGULAR, null,
+        )
+
+        flow.expireAdmin(superSession, targetId)
+            .andExpect { status { isCreated() } }
+
+        val admins = flow.findAllAdmins(superSession)
+        admins.none { it.id == targetId } shouldBe true
+    }
+}


### PR DESCRIPTION
## Summary

- SUPER/REGULAR 역할 구분을 추가하고, 어드민 계정을 생성·만료·PW 변경할 수 있는 관리 UI와 API를 구현
- SUPER 어드민만 다른 어드민을 생성하거나 만료 가능. REGULAR는 본인 PW 변경만 가능
- 계층 구조(parentAdmin) 지원, 중첩 테이블 UI로 표시

## Changes

### Backend
- `AdminRole` enum 추가 (SUPER / REGULAR)
- `Admin` 엔티티: `Audit` 상속, `role` 필드, `expire()` 메서드, `@SQLRestriction` on children
- `AdminDSLRepository`: fetch join으로 N+1 방지
- 신규 API 4개:
  - `GET /v1/maintenance/management/admins` — 활성 어드민 목록 (계층 구조)
  - `POST /v1/maintenance/management/admins` — 어드민 생성 (SUPER 전용)
  - `POST /v1/maintenance/management/admin/{id}/expire` — 만료 (SUPER 전용)
  - `PUT /v1/maintenance/management/admin/{id}/pw` — PW 변경 (SUPER 전체, REGULAR 본인만)
- 기존 `AdminController.modifyInfo`의 `pw!!` NPE 버그 수정

### Frontend
- 어드민 관리 페이지 (`/view/management/admins`) — 목록·추가·PW변경 팝업 포함
- 좌측 사이드바에 "어드민 관리" 링크 추가

## Test plan

- [ ] SUPER 어드민 생성 → status=true 확인
- [ ] REGULAR로 어드민 생성 시도 → 403 반환
- [ ] SUPER로 타인 만료 → 목록에서 사라짐
- [ ] SUPER 본인 만료 시도 → 400 반환
- [ ] REGULAR로 타인 만료 시도 → 403 반환
- [ ] SUPER로 타인 PW 변경 → 성공
- [ ] REGULAR로 본인 PW 변경 → 성공
- [ ] REGULAR로 타인 PW 변경 → 403 반환