### PR TITLE
feat: authorization audit logging for Grafana/Loki pipeline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/AuthorizationAuditAspect.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/AuthorizationAuditAspect.kt
@@ -2,6 +2,7 @@ package io.mustelidae.otter.lutrogale.api.domain.authorization
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.mustelidae.otter.lutrogale.api.domain.authorization.api.AccessResources
+import io.mustelidae.otter.lutrogale.api.permission.RoleHeader
 import io.mustelidae.otter.lutrogale.common.Replies
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
@@ -30,7 +31,7 @@ class AuthorizationAuditAspect(
         val startTime = System.currentTimeMillis()
         val servletRequest = (RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes)?.request
 
-        val rawApiKey = servletRequest?.getHeader("x-system-id") ?: (pjp.args.getOrNull(0) as? String) ?: ""
+        val rawApiKey = servletRequest?.getHeader(RoleHeader.XSystem.KEY) ?: (pjp.args.getOrNull(0) as? String) ?: ""
         val apiKey = maskApiKey(rawApiKey)
         val clientIp = servletRequest?.remoteAddr ?: ""
         val userAgent = servletRequest?.getHeader("User-Agent") ?: ""
@@ -83,7 +84,7 @@ class AuthorizationAuditAspect(
         return result
     }
 
-    private fun extractEmail(args: Array<Any>): String {
+    private fun extractEmail(args: Array<out Any?>): String {
         return when (val req = args.getOrNull(1)) {
             is AccessResources.Request.IdBase -> req.email
             is AccessResources.Request.UriBase -> req.email
@@ -100,6 +101,7 @@ class AuthorizationAuditAspect(
     }
 
     private fun maskApiKey(apiKey: String): String {
+        if (apiKey.isBlank()) return ""
         if (apiKey.length <= 8) return "****"
         return apiKey.take(8) + "****"
     }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/AuthorizationAuditAspect.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/AuthorizationAuditAspect.kt
@@ -1,0 +1,106 @@
+package io.mustelidae.otter.lutrogale.api.domain.authorization
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mustelidae.otter.lutrogale.api.domain.authorization.api.AccessResources
+import io.mustelidae.otter.lutrogale.common.Replies
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.time.Instant
+
+@Aspect
+@Component
+class AuthorizationAuditAspect(
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val auditLog = LoggerFactory.getLogger("audit.authorization")
+
+    @Around(
+        "execution(* io.mustelidae.otter.lutrogale.api.domain.authorization.api.AuthorizationController.idChecks(..)) || " +
+            "execution(* io.mustelidae.otter.lutrogale.api.domain.authorization.api.AuthorizationController.urlCheck(..)) || " +
+            "execution(* io.mustelidae.otter.lutrogale.api.domain.authorization.api.AuthorizationController.graphQLCheck(..))",
+    )
+    fun audit(pjp: ProceedingJoinPoint): Any? {
+        val startTime = System.currentTimeMillis()
+        val servletRequest = (RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes)?.request
+
+        val rawApiKey = servletRequest?.getHeader("x-system-id") ?: (pjp.args.getOrNull(0) as? String) ?: ""
+        val apiKey = maskApiKey(rawApiKey)
+        val clientIp = servletRequest?.remoteAddr ?: ""
+        val userAgent = servletRequest?.getHeader("User-Agent") ?: ""
+        val txId = MDC.get("txId") ?: ""
+        val email = extractEmail(pjp.args)
+        val checkType = resolveCheckType(pjp.signature.name)
+
+        var caughtException: Throwable? = null
+        val result = try {
+            pjp.proceed()
+        } catch (e: Throwable) {
+            caughtException = e
+            null
+        }
+
+        try {
+            val latencyMs = System.currentTimeMillis() - startTime
+
+            val states = if (caughtException == null) {
+                (result as? Replies<*>)
+                    ?.getContent()
+                    ?.filterIsInstance<AccessResources.Reply.AccessState>()
+                    ?: emptyList()
+            } else {
+                emptyList()
+            }
+            val totalCount = states.size
+            val deniedCount = states.count { !it.hasPermission }
+
+            val entry = linkedMapOf<String, Any?>(
+                "timestamp" to Instant.now().toString(),
+                "txId" to txId,
+                "event" to "authorization_check",
+                "apiKey" to apiKey,
+                "email" to email,
+                "checkType" to checkType,
+                "clientIp" to clientIp,
+                "userAgent" to userAgent,
+                "latencyMs" to latencyMs,
+                "allowed" to (caughtException == null && deniedCount == 0),
+                "deniedCount" to deniedCount,
+                "totalCount" to totalCount,
+            )
+            auditLog.info(objectMapper.writeValueAsString(entry))
+        } catch (e: Exception) {
+            log.warn("Failed to write authorization audit log", e)
+        }
+
+        if (caughtException != null) throw caughtException
+        return result
+    }
+
+    private fun extractEmail(args: Array<Any>): String {
+        return when (val req = args.getOrNull(1)) {
+            is AccessResources.Request.IdBase -> req.email
+            is AccessResources.Request.UriBase -> req.email
+            is AccessResources.Request.GraphQLBase -> req.email
+            else -> ""
+        }
+    }
+
+    private fun resolveCheckType(methodName: String): String = when (methodName) {
+        "idChecks" -> "ID"
+        "urlCheck" -> "URI"
+        "graphQLCheck" -> "GRAPHQL"
+        else -> "UNKNOWN"
+    }
+
+    private fun maskApiKey(apiKey: String): String {
+        if (apiKey.length <= 8) return "****"
+        return apiKey.take(8) + "****"
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/filter/RequestResponseLogFilter.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/filter/RequestResponseLogFilter.kt
@@ -61,21 +61,24 @@ class RequestResponseLogFilter : OncePerRequestFilter() {
                 filterChain.doFilter(multiReadRequest, wrappedResponse)
             } finally {
                 try {
-                    run {
-                        appendTransactionId(messageMap, transactionId)
-                        appendHttpMethod(messageMap, request)
-                        appendUrl(messageMap, "res", request)
-                        appendStatus(messageMap, wrappedResponse)
-                        appendLatency(messageMap, startTime)
+                    try {
+                        run {
+                            appendTransactionId(messageMap, transactionId)
+                            appendHttpMethod(messageMap, request)
+                            appendUrl(messageMap, "res", request)
+                            appendStatus(messageMap, wrappedResponse)
+                            appendLatency(messageMap, startTime)
 
-                        if (log.isDebugEnabled) {
-                            appendResponseBody(messageMap, wrappedResponse)
+                            if (log.isDebugEnabled) {
+                                appendResponseBody(messageMap, wrappedResponse)
+                            }
+
+                            log.info(messageMap.toJson())
+                            messageMap.clear()
                         }
-
-                        log.info(messageMap.toJson())
-                        messageMap.clear()
+                    } catch (e: Exception) {
+                        log.error("Failed to write response log", e)
                     }
-
                     wrappedResponse.copyBodyToResponse()
                 } finally {
                     MDC.remove("txId")

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/filter/RequestResponseLogFilter.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/filter/RequestResponseLogFilter.kt
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletRequestWrapper
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.http.MediaType
 import org.springframework.http.server.ServletServerHttpRequest
 import org.springframework.util.StreamUtils
@@ -42,6 +43,7 @@ class RequestResponseLogFilter : OncePerRequestFilter() {
             val multiReadRequest = request as? MultiReadHttpServletRequest ?: MultiReadHttpServletRequest(request)
             val wrappedResponse = response as? ContentCachingResponseWrapper ?: ContentCachingResponseWrapper(response)
 
+            MDC.put("txId", transactionId)
             try {
                 run {
                     appendTransactionId(messageMap, transactionId)
@@ -58,22 +60,26 @@ class RequestResponseLogFilter : OncePerRequestFilter() {
 
                 filterChain.doFilter(multiReadRequest, wrappedResponse)
             } finally {
-                run {
-                    appendTransactionId(messageMap, transactionId)
-                    appendHttpMethod(messageMap, request)
-                    appendUrl(messageMap, "res", request)
-                    appendStatus(messageMap, wrappedResponse)
-                    appendLatency(messageMap, startTime)
+                try {
+                    run {
+                        appendTransactionId(messageMap, transactionId)
+                        appendHttpMethod(messageMap, request)
+                        appendUrl(messageMap, "res", request)
+                        appendStatus(messageMap, wrappedResponse)
+                        appendLatency(messageMap, startTime)
 
-                    if (log.isDebugEnabled) {
-                        appendResponseBody(messageMap, wrappedResponse)
+                        if (log.isDebugEnabled) {
+                            appendResponseBody(messageMap, wrappedResponse)
+                        }
+
+                        log.info(messageMap.toJson())
+                        messageMap.clear()
                     }
 
-                    log.info(messageMap.toJson())
-                    messageMap.clear()
+                    wrappedResponse.copyBodyToResponse()
+                } finally {
+                    MDC.remove("txId")
                 }
-
-                wrappedResponse.copyBodyToResponse()
             }
         }
     }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <appender name="AUDIT_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/audit.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/audit.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="audit.authorization" level="INFO" additivity="false">
+        <appender-ref ref="AUDIT_FILE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/AuthorizationAuditFlowTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/authorization/AuthorizationAuditFlowTest.kt
@@ -1,0 +1,139 @@
+package io.mustelidae.otter.lutrogale.api.domain.authorization
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldNotContain
+import io.mustelidae.otter.lutrogale.api.config.EmbeddedDbInitializer
+import io.mustelidae.otter.lutrogale.api.config.FlowTestSupport
+import io.mustelidae.otter.lutrogale.api.domain.authorization.api.AccessResources
+import io.mustelidae.otter.lutrogale.api.domain.authorization.api.AuthorizationControllerFlow
+import io.mustelidae.otter.lutrogale.api.permission.RoleHeader
+import io.mustelidae.otter.lutrogale.web.domain.project.repository.ProjectRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.post
+import org.springframework.web.bind.annotation.RequestMethod
+
+internal class AuthorizationAuditFlowTest : FlowTestSupport() {
+
+    @Autowired private lateinit var projectRepository: ProjectRepository
+
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    private val auditLogger = LoggerFactory.getLogger("audit.authorization") as Logger
+    private val listAppender = ListAppender<ILoggingEvent>()
+
+    @BeforeEach
+    fun attachAppender() {
+        listAppender.list.clear()
+        listAppender.start()
+        auditLogger.addAppender(listAppender)
+    }
+
+    @AfterEach
+    fun detachAppender() {
+        auditLogger.detachAppender(listAppender)
+    }
+
+    @Test
+    fun `URI 기반 권한 체크 시 감사 로그가 기록된다`() {
+        val flow = AuthorizationControllerFlow(projectRepository, mockMvc)
+
+        flow.uriCheck(EmbeddedDbInitializer.USER_EMAIL, "/applications/1234/reviews/1234", RequestMethod.GET)
+
+        listAppender.list.size shouldBeGreaterThan 0
+        val entry = objectMapper.readValue<Map<String, Any>>(listAppender.list.last().message)
+
+        entry["event"] shouldBe "authorization_check"
+        entry["email"] shouldBe EmbeddedDbInitializer.USER_EMAIL
+        entry["checkType"] shouldBe "URI"
+        (entry["allowed"] as Boolean).shouldBeTrue()
+        entry["deniedCount"] shouldBe 0
+        entry["totalCount"] shouldBe 1
+        entry["latencyMs"] shouldNotBe null
+    }
+
+    @Test
+    fun `감사 로그에 apiKey는 마스킹되어 기록된다`() {
+        val flow = AuthorizationControllerFlow(projectRepository, mockMvc)
+        val rawApiKey = projectRepository.findAll().first().apiKey
+
+        flow.uriCheck(EmbeddedDbInitializer.USER_EMAIL, "/applications/1234/reviews/1234", RequestMethod.GET)
+
+        val entry = objectMapper.readValue<Map<String, Any>>(listAppender.list.last().message)
+        val maskedApiKey = entry["apiKey"] as String
+        maskedApiKey shouldEndWith "****"
+        maskedApiKey shouldNotContain rawApiKey
+    }
+
+    @Test
+    fun `ID 기반 권한 체크 시 감사 로그 checkType이 ID다`() {
+        val flow = AuthorizationControllerFlow(projectRepository, mockMvc)
+
+        flow.idCheck(EmbeddedDbInitializer.USER_EMAIL, listOf(1, 2, 3))
+
+        val entry = objectMapper.readValue<Map<String, Any>>(listAppender.list.last().message)
+        entry["checkType"] shouldBe "ID"
+        entry["email"] shouldBe EmbeddedDbInitializer.USER_EMAIL
+        entry["totalCount"] shouldBe 3
+    }
+
+    @Test
+    fun `GraphQL 기반 권한 체크 시 감사 로그 checkType이 GRAPHQL이다`() {
+        val flow = AuthorizationControllerFlow(projectRepository, mockMvc)
+
+        flow.graphqlCheck(EmbeddedDbInitializer.USER_EMAIL, "getReviews", RequestMethod.GET)
+
+        val entry = objectMapper.readValue<Map<String, Any>>(listAppender.list.last().message)
+        entry["checkType"] shouldBe "GRAPHQL"
+        entry["email"] shouldBe EmbeddedDbInitializer.USER_EMAIL
+    }
+
+    @Test
+    fun `신규 사용자 요청 시 감사 로그에 denied로 기록된다`() {
+        val flow = AuthorizationControllerFlow(projectRepository, mockMvc)
+        val newUserEmail = "newuser-audit-test@example.com"
+
+        flow.uriCheck(newUserEmail, "/applications/1234/reviews/1234", RequestMethod.GET)
+
+        val entry = objectMapper.readValue<Map<String, Any>>(listAppender.list.last().message)
+        (entry["allowed"] as Boolean).shouldBeFalse()
+        entry["deniedCount"] shouldBe 1
+        entry["totalCount"] shouldBe 1
+    }
+
+    @Test
+    fun `잘못된 apiKey로 요청 시 예외가 발생해도 감사 로그에 allowed=false로 기록된다`() {
+        val request = AccessResources.Request.UriBase(
+            EmbeddedDbInitializer.USER_EMAIL,
+            listOf(AccessResources.AccessUri("/applications/1234/reviews/1234", RequestMethod.GET)),
+        )
+
+        mockMvc.post("/v1/verification/authorization-check/uri") {
+            contentType = MediaType.APPLICATION_JSON
+            header(RoleHeader.XSystem.KEY, "invalid-api-key-that-does-not-exist")
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { is4xxClientError() }
+        }
+
+        listAppender.list.size shouldBeGreaterThan 0
+        val entry = objectMapper.readValue<Map<String, Any>>(listAppender.list.last().message)
+        (entry["allowed"] as Boolean).shouldBeFalse()
+        entry["checkType"] shouldBe "URI"
+        entry["totalCount"] shouldBe 0
+    }
+}


### PR DESCRIPTION
## Summary

- `/v1/verification/authorization-check/*` 세 엔드포인트의 모든 요청을 `logs/audit.log`에 JSON 한 줄로 기록하는 감사 로그 추가
- Promtail → Loki → Grafana 파이프라인으로 수집 가능한 구조화된 포맷
- 예외 케이스(잘못된 apiKey, 만료된 프로젝트)도 `allowed: false`로 감사 로그에 기록

## 감사 로그 JSON 구조

```json
{
  "timestamp": "2026-06-09T04:56:12.345Z",
  "txId": "abc-...",
  "event": "authorization_check",
  "apiKey": "a1b2c3d4****",
  "email": "user@example.com",
  "checkType": "URI",
  "clientIp": "10.0.0.1",
  "userAgent": "ServiceA/1.0",
  "latencyMs": 12,
  "allowed": true,
  "deniedCount": 0,
  "totalCount": 3
}
```

## 주요 변경사항

| 파일 | 내용 |
|------|------|
| `build.gradle.kts` | `spring-boot-starter-aop` 의존성 추가 |
| `AuthorizationAuditAspect.kt` | AOP `@Around` 어드바이스 — 세 체크 엔드포인트 감사 기록 |
| `RequestResponseLogFilter.kt` | MDC `txId`를 nested try-finally로 보호 (MDC 누수 버그 수정 포함) |
| `logback-spring.xml` | `audit.authorization` 로거를 `logs/audit.log`로 분리 (30일, 1GB 상한) |
| `AuthorizationAuditFlowTest.kt` | URI/ID/GraphQL/신규사용자/apiKey마스킹/잘못된apiKey 6개 시나리오 |

## 설계 결정 사항

- **fail-safe**: 감사 로그 기록 실패는 본 요청에 영향 없음 — `pjp.proceed()` 결과를 try-catch 바깥에서 먼저 확보하지 않고, 예외를 catch → 감사 로그 → re-throw 순서로 처리
- **apiKey 마스킹**: 앞 8자 + `****` — 평문 저장 방지
- **예외 감사**: 잘못된 apiKey 등 인증 실패 요청도 `allowed: false`로 기록해 보안 모니터링 커버리지 확보
- **MDC 수명주기**: `copyBodyToResponse()` IOException에서도 `txId`가 스레드 풀로 누수되지 않도록 nested try-finally 적용

## Test plan

- [x] `./gradlew build` — 전체 빌드 및 57개 테스트 통과 확인
- [x] URI 기반 권한 체크 → 감사 로그 JSON 필드 검증
- [x] ID / GraphQL 기반 → `checkType` 필드 검증
- [x] 신규 사용자 → `allowed: false`, `deniedCount == totalCount`
- [x] 잘못된 apiKey → HTTP 4xx이지만 감사 로그에 `allowed: false` 기록
- [x] apiKey 마스킹 → 원본 키 포함 여부 검증
- [ ] 로컬 실행 후 `tail -f logs/audit.log` 로 실시간 JSON 확인