### PR TITLE
feat: bulk user registration for SUPER admins

### DIFF
--- a/e2e/tests/bulk-register.spec.ts
+++ b/e2e/tests/bulk-register.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '../fixtures/auth';
+
+const uniqueEmail = (label: string) => `bulk-e2e-${label}-${Date.now()}@test.com`;
+
+test.describe('사용자 대량 등록 UX', () => {
+  test.beforeEach(async ({ adminPage }) => {
+    await adminPage.goto('/view/management/members');
+    await adminPage.waitForSelector('#tb-users tbody tr');
+  });
+
+  test('대량 등록 버튼이 표시되고 클릭하면 모달이 열린다', async ({ adminPage }) => {
+    const btn = adminPage.locator('button.btn-success', { hasText: '대량 등록' });
+    await expect(btn).toBeVisible();
+
+    await btn.click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    await expect(adminPage.locator('#bulk-emails')).toBeVisible();
+    await expect(adminPage.locator('#bulk-project')).toBeVisible();
+    await expect(adminPage.locator('#bulk-authority')).toBeVisible();
+    await expect(adminPage.locator('input[name="bulk-status"][value="ALLOW"]')).toBeChecked();
+  });
+
+  test('취소 버튼을 누르면 모달이 닫힌다', async ({ adminPage }) => {
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    await adminPage.click('#bulk-register-close');
+    await adminPage.waitForSelector('#modal-bulk-register', { state: 'hidden' });
+  });
+
+  test('WAIT 상태를 선택하면 권한 그룹 셀렉트가 비활성화된다', async ({ adminPage }) => {
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    // 프로젝트 선택 후 권한 그룹 활성화 확인
+    await adminPage.selectOption('#bulk-project', { index: 1 });
+    await adminPage.waitForSelector('#bulk-authority:not([disabled])');
+    await expect(adminPage.locator('#bulk-authority')).toBeEnabled();
+
+    // WAIT 선택 → 권한 그룹 비활성화
+    await adminPage.check('input[name="bulk-status"][value="WAIT"]');
+    await expect(adminPage.locator('#bulk-authority')).toBeDisabled();
+
+    // ALLOW 재선택 → 권한 그룹 재활성화 및 옵션 재로드
+    await adminPage.check('input[name="bulk-status"][value="ALLOW"]');
+    await adminPage.waitForSelector('#bulk-authority:not([disabled])');
+    await expect(adminPage.locator('#bulk-authority')).toBeEnabled();
+  });
+
+  test('프로젝트를 선택하면 권한 그룹 목록이 로드된다', async ({ adminPage }) => {
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    await adminPage.selectOption('#bulk-project', { index: 1 });
+    await adminPage.waitForFunction(() => (document.querySelector('#bulk-authority') as HTMLSelectElement)?.options.length > 1);
+
+    const optionCount = await adminPage.locator('#bulk-authority option').count();
+    expect(optionCount).toBeGreaterThan(1);
+  });
+
+  test('이메일을 입력하지 않고 등록하면 경고 알림이 뜬다', async ({ adminPage }) => {
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    const alertMessage = await new Promise<string>(resolve => {
+      adminPage.once('dialog', dialog => {
+        resolve(dialog.message());
+        dialog.accept();
+      });
+      adminPage.click('#bulk-register-submit');
+    });
+
+    expect(alertMessage).toContain('이메일');
+  });
+
+  test('이메일 11개 입력 시 최대 개수 초과 경고 알림이 뜬다', async ({ adminPage }) => {
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    const tooManyEmails = Array.from({ length: 11 }, (_, i) => `over${i}@test.com`).join(', ');
+    await adminPage.fill('#bulk-emails', tooManyEmails);
+
+    const alertMessage = await new Promise<string>(resolve => {
+      adminPage.once('dialog', dialog => {
+        resolve(dialog.message());
+        dialog.accept();
+      });
+      adminPage.click('#bulk-register-submit');
+    });
+
+    expect(alertMessage).toContain('10개');
+  });
+
+  test('신규 이메일 등록 시 진행률 바가 완료되고 SUCCESS 결과가 표시된다', async ({ adminPage }) => {
+    const email = uniqueEmail('success');
+
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    await adminPage.fill('#bulk-emails', email);
+    await adminPage.click('#bulk-register-submit');
+
+    // 진행 단계로 전환
+    await adminPage.waitForSelector('#bulk-progress-step', { state: 'visible' });
+    await adminPage.waitForSelector('#bulk-form-step', { state: 'hidden' });
+
+    // 진행률 바 완료 대기 (progress-bar active 클래스 제거)
+    await adminPage.waitForFunction(() => {
+      const bar = document.querySelector('#bulk-progress-bar');
+      return bar && !bar.classList.contains('active');
+    }, { timeout: 10_000 });
+
+    // 결과 목록에 SUCCESS 레이블 표시
+    const resultRow = adminPage.locator('#bulk-result-list tr').first();
+    await expect(resultRow).toContainText(email);
+    await expect(resultRow.locator('.label-success')).toContainText('등록 완료');
+  });
+
+  test('이미 존재하는 이메일을 등록하면 SKIPPED 결과가 표시된다', async ({ adminPage }) => {
+    const email = uniqueEmail('skip');
+
+    // 1차 등록
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+    await adminPage.fill('#bulk-emails', email);
+    await adminPage.click('#bulk-register-submit');
+    await adminPage.waitForFunction(() => {
+      const bar = document.querySelector('#bulk-progress-bar');
+      return bar && !bar.classList.contains('active');
+    }, { timeout: 10_000 });
+    await adminPage.click('#bulk-register-close');
+    await adminPage.waitForSelector('#modal-bulk-register', { state: 'hidden' });
+
+    // 2차 등록 — 같은 이메일
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+    await adminPage.fill('#bulk-emails', email);
+    await adminPage.click('#bulk-register-submit');
+    await adminPage.waitForFunction(() => {
+      const bar = document.querySelector('#bulk-progress-bar');
+      return bar && !bar.classList.contains('active');
+    }, { timeout: 10_000 });
+
+    const resultRow = adminPage.locator('#bulk-result-list tr').first();
+    await expect(resultRow).toContainText(email);
+    await expect(resultRow.locator('.label-default')).toContainText('이미 존재');
+  });
+
+  test('쉼표와 공백으로 구분된 이메일이 모두 등록된다', async ({ adminPage }) => {
+    const ts = Date.now();
+    const emails = [
+      `bulk-sep1-${ts}@test.com`,
+      `bulk-sep2-${ts}@test.com`,
+      `bulk-sep3-${ts}@test.com`,
+    ];
+
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    await adminPage.fill('#bulk-emails', `${emails[0]}, ${emails[1]} ${emails[2]}`);
+    await adminPage.click('#bulk-register-submit');
+    await adminPage.waitForFunction(() => {
+      const bar = document.querySelector('#bulk-progress-bar');
+      return bar && !bar.classList.contains('active');
+    }, { timeout: 10_000 });
+
+    const rows = adminPage.locator('#bulk-result-list tr');
+    await expect(rows).toHaveCount(3);
+    await expect(rows.locator('.label-success')).toHaveCount(3);
+
+    const barText = await adminPage.locator('#bulk-progress-bar').textContent();
+    expect(barText).toContain('3 / 3');
+  });
+
+  test('프로젝트·권한 그룹 선택 후 등록하면 전체 워크플로가 완료된다', async ({ adminPage }) => {
+    const email = uniqueEmail('full');
+
+    await adminPage.locator('button.btn-success', { hasText: '대량 등록' }).click();
+    await adminPage.waitForSelector('#modal-bulk-register.in');
+
+    await adminPage.fill('#bulk-emails', email);
+
+    // 프로젝트 선택
+    await adminPage.selectOption('#bulk-project', { index: 1 });
+    await adminPage.waitForFunction(() => (document.querySelector('#bulk-authority') as HTMLSelectElement)?.options.length > 1);
+
+    // 첫 번째 권한 그룹 선택
+    await adminPage.selectOption('#bulk-authority', { index: 1 });
+
+    // ALLOW 상태 확인
+    await expect(adminPage.locator('input[name="bulk-status"][value="ALLOW"]')).toBeChecked();
+
+    await adminPage.click('#bulk-register-submit');
+    await adminPage.waitForFunction(() => {
+      const bar = document.querySelector('#bulk-progress-bar');
+      return bar && !bar.classList.contains('active');
+    }, { timeout: 10_000 });
+
+    const resultRow = adminPage.locator('#bulk-result-list tr').first();
+    await expect(resultRow.locator('.label-success')).toContainText('등록 완료');
+  });
+});

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/UserInteraction.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/UserInteraction.kt
@@ -4,16 +4,21 @@ import io.mustelidae.otter.lutrogale.common.DefaultError
 import io.mustelidae.otter.lutrogale.common.ErrorCode
 import io.mustelidae.otter.lutrogale.config.InvalidArgumentException
 import io.mustelidae.otter.lutrogale.config.PolicyException
+import io.mustelidae.otter.lutrogale.web.domain.grant.UserGrantInteraction
+import io.mustelidae.otter.lutrogale.web.domain.user.api.UserResources
 import io.mustelidae.otter.lutrogale.web.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * Created by seooseok on 2016. 10. 5..
  */
 @Service
+@Transactional
 class UserInteraction(
-    val userRepository: UserRepository,
-    val userFinder: UserFinder,
+    private val userRepository: UserRepository,
+    private val userFinder: UserFinder,
+    private val userGrantInteraction: UserGrantInteraction,
 ) {
 
     fun createBy(email: String, name: String, status: User.Status): User {
@@ -52,6 +57,29 @@ class UserInteraction(
             user.status = status
 
             userRepository.save(user)
+        }
+    }
+
+    fun bulkCreateBy(
+        emails: List<String>,
+        projectId: Long?,
+        authorityDefinitionId: Long?,
+        initialStatus: User.Status,
+    ): List<UserResources.BatchRegister.Result> {
+        if (initialStatus == User.Status.EXPIRE || initialStatus == User.Status.REJECT) {
+            throw InvalidArgumentException("대량 등록 초기 상태는 ALLOW 또는 WAIT만 허용됩니다.")
+        }
+        return emails.map { email ->
+            val existing = userFinder.findBy(email)
+            if (existing != null) {
+                UserResources.BatchRegister.Result(email, UserResources.BatchRegister.Result.Outcome.SKIPPED, null)
+            } else {
+                val user = createBy(email, email.substringBefore("@"), initialStatus)
+                if (initialStatus == User.Status.ALLOW && projectId != null && authorityDefinitionId != null) {
+                    userGrantInteraction.addByAuthorityGrant(user.id!!, projectId, listOf(authorityDefinitionId))
+                }
+                UserResources.BatchRegister.Result(email, UserResources.BatchRegister.Result.Outcome.SUCCESS, user.id)
+            }
         }
     }
 

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserController.kt
@@ -4,34 +4,67 @@ import io.mustelidae.otter.lutrogale.common.Replies
 import io.mustelidae.otter.lutrogale.common.Reply
 import io.mustelidae.otter.lutrogale.common.toReplies
 import io.mustelidae.otter.lutrogale.common.toReply
+import io.mustelidae.otter.lutrogale.config.PermissionException
+import io.mustelidae.otter.lutrogale.web.AdminSession
+import io.mustelidae.otter.lutrogale.web.common.annotation.LoginCheck
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminFinder
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
 import io.mustelidae.otter.lutrogale.web.domain.project.api.ProjectResources
 import io.mustelidae.otter.lutrogale.web.domain.user.UserFinder
 import io.mustelidae.otter.lutrogale.web.domain.user.UserInteraction
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpSession
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "사용자")
+@LoginCheck
 @RestController
 @RequestMapping("/v1/maintenance/management/user")
 class UserController(
     private val userInteraction: UserInteraction,
     private val userFinder: UserFinder,
+    private val adminFinder: AdminFinder,
+    private val httpSession: HttpSession,
 ) {
 
     @Operation(summary = "사용자 추가")
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun create(
         @RequestBody request: UserResources.Request,
     ): Reply<Long> {
         val user = userInteraction.createBy(request.email, request.name, request.isPrivacy, request.department)
         return user.id!!.toReply()
+    }
+
+    @Operation(summary = "사용자 대량 등록 (SUPER 전용)")
+    @PostMapping("/batch")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun batchCreate(
+        @RequestBody @Valid
+        request: UserResources.BatchRegister.Request,
+    ): Replies<UserResources.BatchRegister.Result> {
+        val sessionInfo = AdminSession(httpSession).infoOrThrow()
+        val caller = adminFinder.findBy(sessionInfo.adminId)
+        if (caller.role != AdminRole.SUPER) {
+            throw PermissionException("사용자 대량 등록은 SUPER 권한만 가능합니다.")
+        }
+        return userInteraction.bulkCreateBy(
+            request.emails,
+            request.projectId,
+            request.authorityDefinitionId,
+            request.initialStatus,
+        ).toReplies()
     }
 
     @Operation(summary = "사용자 조회")

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserResources.kt
@@ -8,9 +8,34 @@ import io.mustelidae.otter.lutrogale.web.domain.project.Project
 import io.mustelidae.otter.lutrogale.web.domain.project.api.ProjectResources
 import io.mustelidae.otter.lutrogale.web.domain.user.User
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
 class UserResources {
+
+    class BatchRegister {
+
+        @Schema(name = "Lutrogale.User.BatchRegister.Request")
+        data class Request(
+            @field:Size(min = 1, max = 10)
+            val emails: List<@Email @NotBlank
+            String,>,
+            val projectId: Long?,
+            val authorityDefinitionId: Long?,
+            val initialStatus: User.Status,
+        )
+
+        @Schema(name = "Lutrogale.User.BatchRegister.Result")
+        data class Result(
+            val email: String,
+            val outcome: Outcome,
+            val userId: Long?,
+        ) {
+            enum class Outcome { SUCCESS, SKIPPED }
+        }
+    }
 
     @Schema(name = "Lutrogale.User.Request")
     class Request(

--- a/src/main/resources/templates/management/member/members.ftl
+++ b/src/main/resources/templates/management/member/members.ftl
@@ -26,6 +26,7 @@
                             <div class="btn-group">
                                 <button type="button" class="btn btn-primary" onclick="modifyUserInfo();">사용자정보 수정</button>
                                 <button type="button" class="btn btn-primary" onclick="OsoriRoute.go('view.management.newMember');">사용자 생성</button>
+                                <button type="button" class="btn btn-success" onclick="openBulkRegisterModal();">대량 등록</button>
                             </div>
 
                             <div class="btn-group pull-right">
@@ -202,6 +203,63 @@
         </div>
 
         <@layout.plainModal "" "modal-fullsize" "modal-group-detail" ""/>
+        <div id="modal-bulk-register" class="modal fade" role="dialog" data-backdrop="static" data-keyboard="false">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">x</span></button>
+                        <h4 class="modal-title">사용자 대량 등록</h4>
+                    </div>
+                    <div class="modal-body">
+                        <div id="bulk-form-step">
+                            <div class="form-group">
+                                <label>이메일 목록 <small class="text-muted">(쉼표 또는 공백으로 구분, 최대 10개)</small></label>
+                                <textarea id="bulk-emails" class="form-control" rows="4"
+                                    placeholder="예) user1@example.com, user2@example.com user3@example.com"></textarea>
+                            </div>
+                            <div class="form-group">
+                                <label>프로젝트 <small class="text-muted">(선택)</small></label>
+                                <select id="bulk-project" class="form-control">
+                                    <option value="">-- 선택 안 함 --</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label>권한 그룹 <small class="text-muted">(선택, 프로젝트 선택 시 활성화)</small></label>
+                                <select id="bulk-authority" class="form-control" disabled>
+                                    <option value="">-- 선택 안 함 --</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label>초기 상태</label>
+                                <div>
+                                    <label class="radio-inline">
+                                        <input type="radio" name="bulk-status" value="ALLOW" checked> 허용 (ALLOW)
+                                    </label>
+                                    <label class="radio-inline">
+                                        <input type="radio" name="bulk-status" value="WAIT"> 대기 (WAIT)
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="bulk-progress-step" style="display:none">
+                            <div class="progress">
+                                <div id="bulk-progress-bar" class="progress-bar progress-bar-striped active"
+                                     role="progressbar" style="width:0%">0 / 0</div>
+                            </div>
+                            <table class="table table-condensed" style="margin-top:10px">
+                                <thead><tr><th>이메일</th><th>결과</th></tr></thead>
+                                <tbody id="bulk-result-list"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button id="bulk-register-close" type="button" class="btn btn-default pull-left" data-dismiss="modal">취소</button>
+                        <button id="bulk-register-submit" type="button" class="btn btn-success">등록</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <@layout.plainModal "" "modal-dialog" "modal-user-status" "true"/>
         <@layout.plainModal "" "modal-fullsize" "modal-modify-user" "true"/>
 
@@ -504,6 +562,119 @@
                     });
                 }
 
+            });
+
+            function openBulkRegisterModal() {
+                $('#bulk-form-step').show();
+                $('#bulk-progress-step').hide();
+                $('#bulk-emails').val('');
+                $('#bulk-project').val('');
+                $('#bulk-authority').val('').prop('disabled', true).html('<option value="">-- 선택 안 함 --</option>');
+                $('input[name="bulk-status"][value="ALLOW"]').prop('checked', true);
+                $('#bulk-register-submit').show().prop('disabled', false);
+                $('#bulk-register-close').text('취소');
+                $('#bulk-result-list').empty();
+
+                AJAX.getData('/v1/maintenance/projects').done(function(data) {
+                    let $select = $('#bulk-project').html('<option value="">-- 선택 안 함 --</option>');
+                    $.each(data.content, function(i, p) {
+                        $select.append('<option value="' + p.id + '">' + p.name + '</option>');
+                    });
+                });
+
+                $('#modal-bulk-register').modal('show');
+            }
+
+            $('#bulk-project').change(function() {
+                let pid = $(this).val();
+                let $authSelect = $('#bulk-authority');
+                $authSelect.prop('disabled', true).html('<option value="">-- 선택 안 함 --</option>');
+                $('input[name="bulk-status"]').prop('disabled', false);
+
+                if (!pid) return;
+
+                AJAX.getData('/v1/maintenance/project/' + pid + '/authority-bundles').done(function(data) {
+                    $.each(data.content, function(i, a) {
+                        $authSelect.append('<option value="' + a.authId + '">' + a.name + '</option>');
+                    });
+                    $authSelect.prop('disabled', false);
+                });
+            });
+
+            $('input[name="bulk-status"]').change(function() {
+                if ($(this).val() === 'WAIT') {
+                    $('#bulk-authority').val('').prop('disabled', true);
+                } else {
+                    let pid = $('#bulk-project').val();
+                    if (pid) {
+                        $('#bulk-project').trigger('change');
+                    }
+                }
+            });
+
+            $('#bulk-register-submit').click(function() {
+                let rawText = $('#bulk-emails').val().trim();
+                if (!rawText) { alert('이메일을 입력해주세요.'); return; }
+
+                let emails = rawText.split(/[\s,]+/).filter(function(e) { return e.length > 0; });
+                if (emails.length === 0) { alert('유효한 이메일이 없습니다.'); return; }
+                if (emails.length > 10) { alert('이메일은 최대 10개까지 입력 가능합니다.'); return; }
+
+                let projectId = $('#bulk-project').val() || null;
+                let authorityDefinitionId = $('#bulk-authority').val() || null;
+                let initialStatus = $('input[name="bulk-status"]:checked').val();
+
+                let payload = { emails: emails, projectId: projectId, authorityDefinitionId: authorityDefinitionId, initialStatus: initialStatus };
+                if (projectId) payload.projectId = parseInt(projectId);
+                if (authorityDefinitionId) payload.authorityDefinitionId = parseInt(authorityDefinitionId);
+
+                $('#bulk-form-step').hide();
+                $('#bulk-progress-step').show();
+                $('#bulk-register-submit').hide();
+                $('#bulk-register-close').text('닫기');
+
+                let total = emails.length;
+                $('#bulk-progress-bar').css('width', '0%').text('0 / ' + total);
+
+                $.ajax({
+                    url: '/v1/maintenance/management/user/batch',
+                    type: 'POST',
+                    contentType: 'application/json',
+                    data: JSON.stringify(payload),
+                    success: function(res) {
+                        let results = res.content;
+                        let shown = 0;
+                        let intervalId = setInterval(function() {
+                            if (shown >= results.length) {
+                                clearInterval(intervalId);
+                                $('#bulk-progress-bar').removeClass('active');
+                                let tb_users = $('#tb-users').DataTable();
+                                AJAX.getData(OsoriRoute.getUri("users.findAll")).done(function(data) {
+                                    tb_users.clear().rows.add(data.content).draw();
+                                });
+                                return;
+                            }
+                            let r = results[shown];
+                            let isSuccess = r.outcome === 'SUCCESS';
+                            let $label = isSuccess
+                                ? $('<span class="label label-success">').text('등록 완료')
+                                : $('<span class="label label-default">').text('이미 존재');
+                            let $row = $('<tr>').append($('<td>').text(r.email)).append($('<td>').append($label));
+                            $('#bulk-result-list').append($row);
+                            shown++;
+                            let pct = Math.round(shown / total * 100);
+                            $('#bulk-progress-bar').css('width', pct + '%').text(shown + ' / ' + total);
+                        }, 100);
+                    },
+                    error: function(res) {
+                        $('#bulk-form-step').show();
+                        $('#bulk-progress-step').hide();
+                        $('#bulk-register-submit').show();
+                        $('#bulk-register-close').text('취소');
+                        let msg = (res.responseJSON && res.responseJSON.message) ? res.responseJSON.message : '등록 중 오류가 발생했습니다.';
+                        alert(msg);
+                    }
+                });
             });
 		</script>
 	</body>

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerFlow.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerFlow.kt
@@ -1,0 +1,63 @@
+package io.mustelidae.otter.lutrogale.web.domain.user.api
+
+import io.mustelidae.otter.lutrogale.common.Replies
+import io.mustelidae.otter.lutrogale.common.Reply
+import io.mustelidae.otter.lutrogale.utils.fromJson
+import io.mustelidae.otter.lutrogale.utils.toJson
+import jakarta.servlet.http.Cookie
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActionsDsl
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+internal class UserBulkRegisterControllerFlow(private val mockMvc: MockMvc) {
+
+    fun login(email: String, password: String): Cookie {
+        val body = mapOf("email" to email, "password" to password)
+        val response = mockMvc.post("/v1/check-login") {
+            contentType = MediaType.APPLICATION_JSON
+            content = body.toJson()
+        }.andExpect {
+            status { is2xxSuccessful() }
+        }.andReturn().response
+
+        return response.getCookie("SESSION")
+            ?: error("SESSION cookie not found after login")
+    }
+
+    fun bulkRegister(session: Cookie, request: UserResources.BatchRegister.Request): List<UserResources.BatchRegister.Result> {
+        return mockMvc.post("/v1/maintenance/management/user/batch") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+            content = request.toJson()
+        }.andExpect {
+            status { isCreated() }
+        }.andReturn()
+            .response
+            .contentAsString
+            .fromJson<Replies<UserResources.BatchRegister.Result>>()
+            .getContent()
+            .toList()
+    }
+
+    fun bulkRegisterExpectFail(session: Cookie, request: UserResources.BatchRegister.Request): ResultActionsDsl {
+        return mockMvc.post("/v1/maintenance/management/user/batch") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+            content = request.toJson()
+        }
+    }
+
+    fun findUserDetail(session: Cookie, userId: Long): UserResources.Reply.Detail {
+        return mockMvc.get("/v1/maintenance/management/user/$userId") {
+            cookie(session)
+        }.andExpect {
+            status { is2xxSuccessful() }
+        }.andReturn()
+            .response
+            .contentAsString
+            .fromJson<Reply<UserResources.Reply.Detail>>()
+            .content!!
+    }
+}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerTest.kt
@@ -1,0 +1,179 @@
+package io.mustelidae.otter.lutrogale.web.domain.user.api
+
+import io.kotest.matchers.shouldBe
+import io.mustelidae.otter.lutrogale.api.config.EmbeddedDbInitializer
+import io.mustelidae.otter.lutrogale.api.config.FlowTestSupport
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminInteraction
+import io.mustelidae.otter.lutrogale.web.domain.admin.AdminRole
+import io.mustelidae.otter.lutrogale.web.domain.authority.repository.AuthorityDefinitionRepository
+import io.mustelidae.otter.lutrogale.web.domain.grant.UserGrantInteraction
+import io.mustelidae.otter.lutrogale.web.domain.project.repository.ProjectRepository
+import io.mustelidae.otter.lutrogale.web.domain.user.User
+import io.mustelidae.otter.lutrogale.web.domain.user.repository.UserRepository
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+internal class UserBulkRegisterControllerTest : FlowTestSupport() {
+
+    @Autowired
+    private lateinit var adminInteraction: AdminInteraction
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var projectRepository: ProjectRepository
+
+    @Autowired
+    private lateinit var authorityDefinitionRepository: AuthorityDefinitionRepository
+
+    @Autowired
+    private lateinit var userGrantInteraction: UserGrantInteraction
+
+    private lateinit var flow: UserBulkRegisterControllerFlow
+    private lateinit var superSession: Cookie
+    private var projectId: Long = 0
+    private var authorityDefinitionId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        flow = UserBulkRegisterControllerFlow(mockMvc)
+        superSession = flow.login("admin@osori.com", "admin")
+        projectId = projectRepository.findAll().first().id!!
+        authorityDefinitionId = authorityDefinitionRepository.findAll().first()!!.id!!
+    }
+
+    @Test
+    fun `SUPER 어드민이 신규 이메일 목록을 등록하면 모두 SUCCESS를 반환한다`() {
+        val request = UserResources.BatchRegister.Request(
+            emails = listOf("bulk1@test.com", "bulk2@test.com"),
+            projectId = null,
+            authorityDefinitionId = null,
+            initialStatus = User.Status.ALLOW,
+        )
+
+        val results = flow.bulkRegister(superSession, request)
+
+        results.size shouldBe 2
+        results.all { it.outcome == UserResources.BatchRegister.Result.Outcome.SUCCESS } shouldBe true
+        results.all { it.userId != null } shouldBe true
+    }
+
+    @Test
+    fun `이미 등록된 이메일은 SKIPPED를 반환하고 신규 이메일은 SUCCESS를 반환한다`() {
+        val request = UserResources.BatchRegister.Request(
+            emails = listOf(EmbeddedDbInitializer.USER_EMAIL, "new-user@test.com"),
+            projectId = null,
+            authorityDefinitionId = null,
+            initialStatus = User.Status.ALLOW,
+        )
+
+        val results = flow.bulkRegister(superSession, request)
+
+        results.size shouldBe 2
+        results.first { it.email == EmbeddedDbInitializer.USER_EMAIL }.outcome shouldBe UserResources.BatchRegister.Result.Outcome.SKIPPED
+        results.first { it.email == "new-user@test.com" }.outcome shouldBe UserResources.BatchRegister.Result.Outcome.SUCCESS
+    }
+
+    @Test
+    fun `전부 중복 이메일이면 전부 SKIPPED를 반환한다`() {
+        val request = UserResources.BatchRegister.Request(
+            emails = listOf(EmbeddedDbInitializer.USER_EMAIL),
+            projectId = null,
+            authorityDefinitionId = null,
+            initialStatus = User.Status.ALLOW,
+        )
+
+        val results = flow.bulkRegister(superSession, request)
+
+        results.size shouldBe 1
+        results.first().outcome shouldBe UserResources.BatchRegister.Result.Outcome.SKIPPED
+        results.first().userId shouldBe null
+    }
+
+    @Test
+    fun `ALLOW 상태로 등록하고 권한그룹 선택 시 사용자가 생성되고 권한이 부여된다`() {
+        val email = "bulk-with-grant@test.com"
+        val request = UserResources.BatchRegister.Request(
+            emails = listOf(email),
+            projectId = projectId,
+            authorityDefinitionId = authorityDefinitionId,
+            initialStatus = User.Status.ALLOW,
+        )
+
+        val results = flow.bulkRegister(superSession, request)
+
+        results.first().outcome shouldBe UserResources.BatchRegister.Result.Outcome.SUCCESS
+        val userId = results.first().userId!!
+        val user = userRepository.findById(userId).orElseThrow()
+        user.status shouldBe User.Status.ALLOW
+        userGrantInteraction.getUserAuthorityGrants(userId, projectId).isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `WAIT 상태로 등록하면 사용자만 생성되고 권한은 부여되지 않는다`() {
+        val email = "bulk-wait@test.com"
+        val request = UserResources.BatchRegister.Request(
+            emails = listOf(email),
+            projectId = projectId,
+            authorityDefinitionId = authorityDefinitionId,
+            initialStatus = User.Status.WAIT,
+        )
+
+        val results = flow.bulkRegister(superSession, request)
+
+        results.first().outcome shouldBe UserResources.BatchRegister.Result.Outcome.SUCCESS
+        val userId = results.first().userId!!
+        val user = userRepository.findById(userId).orElseThrow()
+        user.status shouldBe User.Status.WAIT
+        userGrantInteraction.getUserAuthorityGrants(userId, projectId).isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `SUPER 아닌 어드민이 호출하면 401을 반환한다`() {
+        adminInteraction.registerBy("regular@bulk-test.com", "pw", "레귤러", null, null, AdminRole.REGULAR, null)
+        val regularSession = flow.login("regular@bulk-test.com", "pw")
+
+        val request = UserResources.BatchRegister.Request(
+            emails = listOf("some@test.com"),
+            projectId = null,
+            authorityDefinitionId = null,
+            initialStatus = User.Status.ALLOW,
+        )
+
+        flow.bulkRegisterExpectFail(regularSession, request)
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `이메일 11개를 입력하면 400을 반환한다`() {
+        val request = UserResources.BatchRegister.Request(
+            emails = (1..11).map { "overflow$it@test.com" },
+            projectId = null,
+            authorityDefinitionId = null,
+            initialStatus = User.Status.ALLOW,
+        )
+
+        flow.bulkRegisterExpectFail(superSession, request)
+            .andExpect { status { isBadRequest() } }
+    }
+
+    @Test
+    fun `이름은 이메일 at 앞부분으로 설정된다`() {
+        val email = "john.doe@example.com"
+        val request = UserResources.BatchRegister.Request(
+            emails = listOf(email),
+            projectId = null,
+            authorityDefinitionId = null,
+            initialStatus = User.Status.ALLOW,
+        )
+
+        val results = flow.bulkRegister(superSession, request)
+
+        val userId = results.first().userId!!
+        val user = userRepository.findById(userId).orElseThrow()
+        user.name shouldBe "john.doe"
+    }
+}


### PR DESCRIPTION
## Summary

- `POST /v1/maintenance/management/user/batch` 엔드포인트 추가 (SUPER 계정 전용)
- 이메일 목록(최대 10개, 쉼표/공백 구분)을 한 번에 등록, 중복은 SKIPPED 처리
- 프로젝트 + 권한 그룹 선택 시 ALLOW 상태로 등록하면 권한 부여까지 자동 처리
- 사용자 이름은 이메일 `@` 앞부분으로 자동 설정
- AdminLTE 모달 UI: 프로젝트/권한 그룹 AJAX 로드, 진행률 바, 이메일별 결과 표시
- 기존 버그 수정: `UserController`에 누락된 `@LoginCheck`, `@ResponseStatus(CREATED)`
- Playwright e2e 테스트 9개 추가 (`e2e/tests/bulk-register.spec.ts`)
- 통합 테스트 8개 추가 (`UserBulkRegisterControllerTest`)

## Bug fixes included

- `AuthorityBundleResources.Reply.AuthorityBundle.id`는 `@JsonProperty("authId")`로 직렬화됨 — FTL에서 `a.id` → `a.authId` 수정
- Playwright에서 `<option>` 요소는 `<select>` 닫혀있을 때 항상 hidden 판정 → `waitForSelector` 대신 `waitForFunction`으로 교체

## Test plan

- [ ] `./gradlew test` 전체 통과 확인
- [ ] `./e2e-test.sh` — 9개 Playwright 테스트 통과 확인
- [ ] SUPER 계정(`admin@osori.com`)으로 로그인 → 사용자 관리 페이지 → 대량 등록 버튼 클릭
- [ ] 이메일 여러 개 입력, 프로젝트/권한 그룹 선택 후 등록 → 진행률 바 및 결과 확인
- [ ] 중복 이메일 포함 재시도 → SKIPPED 결과 확인
- [ ] SUPER 아닌 계정으로 호출 → 403 확인