### PR TITLE
fix: swagger-ui errors, deprecated API, footer update, DTO @Schema conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,10 +150,18 @@ sd 'old' 'new' file.kt     # sed 대신
 ### Code Style
 
 - 새 엔티티는 `Audit` 상속, `@Audited(targetAuditMode = NOT_AUDITED)` 적용
-- Controller는 `*Resources` inner object로 Request/Reply DTO를 정의
+- `*Resources.kt` inner class 생성 규칙 (HTTP 메서드 기준):
+  - `POST` → `Request` inner class 하위에 DTO 생성
+  - `PUT`, `PATCH` → `Modify` inner class 하위에 DTO 생성
+  - `DELETE` → `Remove` inner class 하위에 DTO 생성
+  - 응답 DTO는 HTTP 메서드와 무관하게 `Reply` inner class 하위에 생성
 - 비즈니스 로직은 `*Interaction`에. `*Finder`는 읽기 전용.
 - 연관관계 편의 메서드는 `addBy(entity)` / `setBy(entity)` 형식
 - `status = true/false` soft delete 패턴 사용. `@SQLRestriction("status = true")` 적용.
+- `*Resources.kt`의 DTO inner class에는 `@Schema(name = "...")` 어노테이션을 반드시 달고, 이름은 `Lutrogale.{Domain}.{InnerClassPath}` 규칙을 따른다.
+  - `{Domain}`: `*Resources.kt`의 `*` 부분 (예: `User`, `Admin`, `Access`)
+  - `{InnerClassPath}`: 클래스 경로를 점(`.`)으로 이어 씀 (예: `Request.BatchRegister`, `Reply.Simple`, `Modify.Info`)
+  - 예) `Lutrogale.User.Request.BatchRegister`, `Lutrogale.User.Reply.Simple`, `Lutrogale.User.Modify.Info`
 
 ### Testing Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,17 +151,18 @@ sd 'old' 'new' file.kt     # sed 대신
 
 - 새 엔티티는 `Audit` 상속, `@Audited(targetAuditMode = NOT_AUDITED)` 적용
 - `*Resources.kt` inner class 생성 규칙 (HTTP 메서드 기준):
-  - `POST` → `Request` inner class 하위에 DTO 생성
+  - `POST` → `Request` inner class 하위에 `Create` inner class로 DTO 생성
   - `PUT`, `PATCH` → `Modify` inner class 하위에 DTO 생성
   - `DELETE` → `Remove` inner class 하위에 DTO 생성
   - 응답 DTO는 HTTP 메서드와 무관하게 `Reply` inner class 하위에 생성
+  - `Request`, `Modify`, `Remove`, `Reply`는 순수 네임스페이스 역할만 하며, 직접 DTO가 되어서는 안 된다.
 - 비즈니스 로직은 `*Interaction`에. `*Finder`는 읽기 전용.
 - 연관관계 편의 메서드는 `addBy(entity)` / `setBy(entity)` 형식
 - `status = true/false` soft delete 패턴 사용. `@SQLRestriction("status = true")` 적용.
 - `*Resources.kt`의 DTO inner class에는 `@Schema(name = "...")` 어노테이션을 반드시 달고, 이름은 `Lutrogale.{Domain}.{InnerClassPath}` 규칙을 따른다.
   - `{Domain}`: `*Resources.kt`의 `*` 부분 (예: `User`, `Admin`, `Access`)
-  - `{InnerClassPath}`: 클래스 경로를 점(`.`)으로 이어 씀 (예: `Request.BatchRegister`, `Reply.Simple`, `Modify.Info`)
-  - 예) `Lutrogale.User.Request.BatchRegister`, `Lutrogale.User.Reply.Simple`, `Lutrogale.User.Modify.Info`
+  - `{InnerClassPath}`: 클래스 경로를 점(`.`)으로 이어 씀 (예: `Request.Create`, `Request.BatchRegister`, `Reply.Simple`, `Modify.Info`)
+  - 예) `Lutrogale.User.Request.Create`, `Lutrogale.User.Request.BatchRegister`, `Lutrogale.User.Reply.Simple`, `Lutrogale.User.Modify.Info`
 
 ### Testing Rules
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 
     implementation("io.swagger.parser.v3:swagger-parser-v2-converter:2.1.20")
+    implementation("javax.xml.bind:jaxb-api:2.3.1") // swagger-parser-v2-converter uses javax.xml.bind (removed in JDK 11+)
 
     kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
     implementation("com.querydsl:querydsl-core:5.1.0")

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/DbInitializer.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/DbInitializer.kt
@@ -52,7 +52,7 @@ class DbInitializer(
     private fun addUser(timestamp: Long): Long =
         userController
             .create(
-                UserResources.Request(
+                UserResources.Request.Create(
                     "test-$timestamp@otter.com",
                     "Lutrogale Otter",
                     false,
@@ -135,7 +135,7 @@ class DbInitializer(
     private fun addProject(timestamp: Long): Long =
         projectController
             .create(
-                ProjectResources.Request(
+                ProjectResources.Request.Create(
                     "Otter Project $timestamp",
                     "This is Sample Project created at $timestamp",
                 ),

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/login/LoginApiController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/login/LoginApiController.kt
@@ -22,7 +22,7 @@ class LoginApiController(
     @Operation(hidden = true)
     @PostMapping("/v1/check-login")
     fun checkLogin(
-        @RequestBody request: LoginResources.Request,
+        @RequestBody request: LoginResources.Request.Create,
         httpServletRequest: HttpServletRequest,
     ): Reply<String> {
         val admin: Admin = adminLoginInteraction.loginCheck(request.email, request.password)

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/login/LoginResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/login/LoginResources.kt
@@ -3,9 +3,11 @@ package io.mustelidae.otter.lutrogale.api.domain.login
 import io.swagger.v3.oas.annotations.media.Schema
 
 class LoginResources {
-    @Schema(name = "Lutrogale.Login.Request")
-    class Request(
-        val email: String,
-        val password: String,
-    )
+    class Request {
+        @Schema(name = "Lutrogale.Login.Request.Create")
+        data class Create(
+            val email: String,
+            val password: String,
+        )
+    }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/MigrationResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/MigrationResources.kt
@@ -1,9 +1,11 @@
 package io.mustelidae.otter.lutrogale.api.domain.migration.api
 
 import io.mustelidae.otter.lutrogale.api.domain.migration.graphql.HttpOperation
+import io.swagger.v3.oas.annotations.media.Schema
 
 class MigrationResources {
     class Request {
+        @Schema(name = "Lutrogale.Migration.Request.OpenAPI")
         data class OpenAPI(
             val url: String,
             val version: String,
@@ -22,12 +24,14 @@ class MigrationResources {
             }
         }
 
+        @Schema(name = "Lutrogale.Migration.Request.GraphQL")
         data class GraphQL(
             val url: String,
             val httpOperation: HttpOperation,
             val header: List<Header>? = null,
         )
 
+        @Schema(name = "Lutrogale.Migration.Request.Header")
         data class Header(
             val key: String,
             val value: String,

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/StableHttpSpecClient.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/StableHttpSpecClient.kt
@@ -50,7 +50,6 @@ class StableHttpSpecClient(
         requestHeader.add(contentType)
         return restClient
             .get(url, requestHeader)
-            .orElseThrow()
     }
 
     /**
@@ -73,6 +72,5 @@ class StableHttpSpecClient(
         requestHeader.add(Pair("Content-Type", ContentType.TEXT_PLAIN))
         return restClient
             .get(url, requestHeader)
-            .orElseThrow()
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/utils/RestClient.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/utils/RestClient.kt
@@ -6,16 +6,24 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
 import org.apache.hc.core5.util.TimeValue
-import java.util.concurrent.TimeUnit
+import org.apache.hc.core5.util.Timeout
+import org.apache.hc.client5.http.config.ConnectionConfig as HttpConnectionConfig
 
 object RestClient {
     fun new(connInfo: ConnectionConfig): CloseableHttpClient {
+        val httpConnConfig =
+            HttpConnectionConfig
+                .custom()
+                .setConnectTimeout(Timeout.ofMilliseconds(connInfo.connTimeout.toLong()))
+                .setTimeToLive(TimeValue.ofSeconds(connInfo.connLiveDuration))
+                .build()
+
         val manager =
             PoolingHttpClientConnectionManagerBuilder
                 .create()
                 .setMaxConnPerRoute(connInfo.perRoute)
                 .setMaxConnTotal(connInfo.connTotal)
-                .setConnectionTimeToLive(TimeValue.ofSeconds(connInfo.connLiveDuration))
+                .setDefaultConnectionConfig(httpConnConfig)
                 .build()
 
         return HttpClients
@@ -24,8 +32,7 @@ object RestClient {
             .setDefaultRequestConfig(
                 RequestConfig
                     .custom()
-                    .setConnectTimeout(connInfo.connTimeout.toLong(), TimeUnit.SECONDS)
-                    .setResponseTimeout(connInfo.readTimeout * 2, TimeUnit.SECONDS)
+                    .setResponseTimeout(Timeout.ofMilliseconds(connInfo.readTimeout * 2))
                     .build(),
             ).build()
     }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/utils/RestClientSupport.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/utils/RestClientSupport.kt
@@ -13,7 +13,7 @@ import org.apache.hc.client5.http.classic.methods.HttpPost
 import org.apache.hc.client5.http.classic.methods.HttpPut
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
+import org.apache.hc.core5.http.ClassicHttpResponse
 import org.apache.hc.core5.http.Header
 import org.apache.hc.core5.http.io.entity.EntityUtils
 import org.apache.hc.core5.http.io.entity.StringEntity
@@ -33,21 +33,20 @@ open class RestClientSupport(
         url: String,
         headers: List<Pair<String, Any>>,
         body: Any? = null,
-    ): CloseableHttpResponse {
+    ): String {
         val post =
             HttpPost(url).apply {
                 body?.let { entity = StringEntity(it.toJson()) }
                 headers.forEach { addHeader(it.first, it.second) }
             }
-
-        return this.execute(post)
+        return this.execute(post) { response -> handleResponse(response) }
     }
 
     fun CloseableHttpClient.post(
         url: String,
         headers: List<Pair<String, Any>>,
         params: List<Pair<String, String>>? = null,
-    ): CloseableHttpResponse {
+    ): String {
         val post =
             HttpPost(url).apply {
                 params
@@ -56,97 +55,76 @@ open class RestClientSupport(
                     }?.let {
                         entity = UrlEncodedFormEntity(it)
                     }
-
-                headers.forEach {
-                    addHeader(it.first, it.second)
-                }
+                headers.forEach { addHeader(it.first, it.second) }
             }
-
-        return this.execute(post)
+        return this.execute(post) { response -> handleResponse(response) }
     }
 
     fun CloseableHttpClient.put(
         url: String,
         headers: List<Pair<String, Any>>,
         body: Any? = null,
-    ): CloseableHttpResponse {
+    ): String {
         val put =
             HttpPut(url).apply {
-                body?.let {
-                    entity = StringEntity(it.toJson())
-                }
-
-                headers.forEach {
-                    addHeader(it.first, it.second)
-                }
+                body?.let { entity = StringEntity(it.toJson()) }
+                headers.forEach { addHeader(it.first, it.second) }
             }
-        return this.execute(put)
+        return this.execute(put) { response -> handleResponse(response) }
     }
 
     fun CloseableHttpClient.patch(
         url: String,
         headers: List<Pair<String, Any>>,
         body: Any? = null,
-    ): CloseableHttpResponse {
+    ): String {
         val patch =
             HttpPatch(url).apply {
-                body?.let {
-                    entity = StringEntity(it.toJson())
-                }
-
-                headers.forEach {
-                    addHeader(it.first, it.second)
-                }
+                body?.let { entity = StringEntity(it.toJson()) }
+                headers.forEach { addHeader(it.first, it.second) }
             }
-
-        return this.execute(patch)
+        return this.execute(patch) { response -> handleResponse(response) }
     }
 
     fun CloseableHttpClient.delete(
         url: String,
         headers: List<Pair<String, Any>>,
         params: List<Pair<String, Any?>>? = null,
-    ): CloseableHttpResponse {
+    ): String {
         val queryString = params?.joinToString("&") { "${it.first}=${it.second}" }
         val uri = if (queryString.isNullOrBlank().not()) url + "?$queryString" else url
         val delete =
             HttpDelete(uri).apply {
-                headers.forEach {
-                    addHeader(it.first, it.second)
-                }
+                headers.forEach { addHeader(it.first, it.second) }
             }
-
-        return this.execute(delete)
+        return this.execute(delete) { response -> handleResponse(response) }
     }
 
     fun CloseableHttpClient.get(
         url: String,
         headers: List<Pair<String, Any>>,
         params: List<Pair<String, Any?>>? = null,
-    ): CloseableHttpResponse {
+    ): String {
         val queryString = params?.joinToString("&") { "${it.first}=${it.second}" }
         val uri = if (queryString.isNullOrBlank().not()) url + "?$queryString" else url
         val get =
             HttpGet(uri).apply {
-                headers.forEach {
-                    addHeader(it.first, it.second)
-                }
+                headers.forEach { addHeader(it.first, it.second) }
             }
-
-        return this.execute(get)
+        return this.execute(get) { response -> handleResponse(response) }
     }
 
-    fun CloseableHttpResponse.orElseThrow(): String {
-        val response = EntityUtils.toString(this.entity, Charset.defaultCharset())
-        writeLog(this.code, this.headers, response)
+    private fun handleResponse(response: ClassicHttpResponse): String {
+        val body = EntityUtils.toString(response.entity, Charset.defaultCharset())
+        writeLog(response.code, response.headers, body)
 
-        if (this.isOK().not()) {
+        if (HttpStatus.valueOf(response.code).is2xxSuccessful.not()) {
             val error =
-                if (response.isNullOrEmpty()) {
-                    DefaultError(ErrorCode.C000, this.reasonPhrase)
+                if (body.isNullOrEmpty()) {
+                    DefaultError(ErrorCode.C000, response.reasonPhrase)
                 } else {
                     try {
-                        val globalErrorFormat = objectMapper.readValue<GlobalErrorFormat>(response)
+                        val globalErrorFormat = objectMapper.readValue<GlobalErrorFormat>(body)
                         DefaultError(ErrorCode.C000, globalErrorFormat.message).apply {
                             refCode = globalErrorFormat.refCode
                             causeBy =
@@ -156,38 +134,14 @@ open class RestClientSupport(
                                 )
                         }
                     } catch (ex: Exception) {
-                        DefaultError(ErrorCode.C000, response)
+                        DefaultError(ErrorCode.C000, body)
                     }
                 }
-
             throw CommunicationException(error)
         }
 
-        return response
+        return body
     }
-
-    fun <T : ExternalServiceError> CloseableHttpResponse.orElseThrow(clazz: Class<T>): String {
-        val response = EntityUtils.toString(this.entity, Charset.defaultCharset())
-        writeLog(this.code, this.headers, response)
-
-        if (this.isOK().not()) {
-            val error =
-                if (response.isNullOrEmpty()) {
-                    DefaultError(ErrorCode.C000, this.reasonPhrase)
-                } else {
-                    val externalError = objectMapper.readValue(response, clazz)
-                    DefaultError(ErrorCode.C000, externalError.message).apply {
-                        refCode = externalError.code
-                    }
-                }
-
-            throw CommunicationException(error)
-        }
-
-        return response
-    }
-
-    private fun CloseableHttpResponse.isOK(): Boolean = (HttpStatus.valueOf(this.code).is2xxSuccessful)
 
     private fun writeLog(
         code: Int,

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectController.kt
@@ -40,7 +40,7 @@ class ProjectController(
     @Operation(summary = "프로젝트 추가")
     @PostMapping("/project")
     fun create(
-        @RequestBody request: ProjectResources.Request,
+        @RequestBody request: ProjectResources.Request.Create,
     ): Reply<Long> {
         val id = projectInteraction.register(request.name, request.description)
         return id.toReply()

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectResources.kt
@@ -5,11 +5,13 @@ import io.mustelidae.otter.lutrogale.web.domain.project.Project
 import io.swagger.v3.oas.annotations.media.Schema
 
 class ProjectResources {
-    @Schema(name = "Lutrogale.Project.Request")
-    data class Request(
-        val name: String,
-        val description: String,
-    )
+    class Request {
+        @Schema(name = "Lutrogale.Project.Request.Create")
+        data class Create(
+            val name: String,
+            val description: String,
+        )
+    }
 
     @Schema(name = "Lutrogale.Project.Reply")
     class Reply(

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/UserInteraction.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/UserInteraction.kt
@@ -78,20 +78,20 @@ class UserInteraction(
         projectId: Long?,
         authorityDefinitionId: Long?,
         initialStatus: User.Status,
-    ): List<UserResources.BatchRegister.Result> {
+    ): List<UserResources.Reply.BatchRegister> {
         if (initialStatus == User.Status.EXPIRE || initialStatus == User.Status.REJECT) {
             throw InvalidArgumentException("대량 등록 초기 상태는 ALLOW 또는 WAIT만 허용됩니다.")
         }
         return emails.map { email ->
             val existing = userFinder.findBy(email)
             if (existing != null) {
-                UserResources.BatchRegister.Result(email, UserResources.BatchRegister.Result.Outcome.SKIPPED, null)
+                UserResources.Reply.BatchRegister(email, UserResources.Reply.BatchRegister.Outcome.SKIPPED, null)
             } else {
                 val user = createBy(email, email.substringBefore("@"), initialStatus)
                 if (initialStatus == User.Status.ALLOW && projectId != null && authorityDefinitionId != null) {
                     userGrantInteraction.addByAuthorityGrant(user.id!!, projectId, listOf(authorityDefinitionId))
                 }
-                UserResources.BatchRegister.Result(email, UserResources.BatchRegister.Result.Outcome.SUCCESS, user.id)
+                UserResources.Reply.BatchRegister(email, UserResources.Reply.BatchRegister.Outcome.SUCCESS, user.id)
             }
         }
     }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserController.kt
@@ -51,8 +51,8 @@ class UserController(
     @ResponseStatus(HttpStatus.CREATED)
     fun batchCreate(
         @RequestBody @Valid
-        request: UserResources.BatchRegister.Request,
-    ): Replies<UserResources.BatchRegister.Result> {
+        request: UserResources.Request.BatchRegister,
+    ): Replies<UserResources.Reply.BatchRegister> {
         val sessionInfo = AdminSession(httpSession).infoOrThrow()
         val caller = adminFinder.findBy(sessionInfo.adminId)
         if (caller.role != AdminRole.SUPER) {

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserController.kt
@@ -40,7 +40,7 @@ class UserController(
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun create(
-        @RequestBody request: UserResources.Request,
+        @RequestBody request: UserResources.Request.Create,
     ): Reply<Long> {
         val user = userInteraction.createBy(request.email, request.name, request.isPrivacy, request.department)
         return user.id!!.toReply()

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserResources.kt
@@ -14,9 +14,15 @@ import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
 class UserResources {
-    class BatchRegister {
-        @Schema(name = "Lutrogale.User.BatchRegister.Request")
-        data class Request(
+    @Schema(name = "Lutrogale.User.Request")
+    class Request(
+        val email: String,
+        val name: String,
+        val isPrivacy: Boolean,
+        val department: String? = null,
+    ) {
+        @Schema(name = "Lutrogale.User.Request.BatchRegister")
+        data class BatchRegister(
             @field:Size(min = 1, max = 10)
             val emails: List<
                 @Email @NotBlank
@@ -26,24 +32,7 @@ class UserResources {
             val authorityDefinitionId: Long?,
             val initialStatus: User.Status,
         )
-
-        @Schema(name = "Lutrogale.User.BatchRegister.Result")
-        data class Result(
-            val email: String,
-            val outcome: Outcome,
-            val userId: Long?,
-        ) {
-            enum class Outcome { SUCCESS, SKIPPED }
-        }
     }
-
-    @Schema(name = "Lutrogale.User.Request")
-    class Request(
-        val email: String,
-        val name: String,
-        val isPrivacy: Boolean,
-        val department: String? = null,
-    )
 
     class Modify {
         @Schema(name = "Lutrogale.User.Modify.Info")
@@ -62,7 +51,16 @@ class UserResources {
     }
 
     class Reply {
-        @Schema(name = "Lutrogale.User.Simple")
+        @Schema(name = "Lutrogale.User.Reply.BatchRegister")
+        data class BatchRegister(
+            val email: String,
+            val outcome: Outcome,
+            val userId: Long?,
+        ) {
+            enum class Outcome { SUCCESS, SKIPPED }
+        }
+
+        @Schema(name = "Lutrogale.User.Reply.Simple")
         data class Simple(
             val id: Long,
             val email: String,
@@ -88,7 +86,7 @@ class UserResources {
             }
         }
 
-        @Schema(name = "Lutrogale.User.Detail")
+        @Schema(name = "Lutrogale.User.Reply.Detail")
         data class Detail(
             val id: Long,
             val email: String,

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserResources.kt
@@ -14,13 +14,15 @@ import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
 class UserResources {
-    @Schema(name = "Lutrogale.User.Request")
-    class Request(
-        val email: String,
-        val name: String,
-        val isPrivacy: Boolean,
-        val department: String? = null,
-    ) {
+    class Request {
+        @Schema(name = "Lutrogale.User.Request.Create")
+        data class Create(
+            val email: String,
+            val name: String,
+            val isPrivacy: Boolean,
+            val department: String? = null,
+        )
+
         @Schema(name = "Lutrogale.User.Request.BatchRegister")
         data class BatchRegister(
             @field:Size(min = 1, max = 10)

--- a/src/main/resources/templates/layout/footer.ftl
+++ b/src/main/resources/templates/layout/footer.ftl
@@ -1,7 +1,8 @@
 
 <footer class="main-footer">
     <div class="pull-right hidden-xs">
-        <b>Version</b> 1.0.0
+        <a href="/swagger-ui.html" target="_blank" title="API Docs"><i class="fa fa-book"></i></a>
+        &nbsp;<b>Version</b> 1.0.3
     </div>
     <strong>Copyright &copy; 2016 - 2024 <a href="https://github.com/stray-cat-developers/lutrogale-otter"></a>Stray cat developers</strong> All rights
     reserved.

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/config/EmbeddedDbInitializer.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/config/EmbeddedDbInitializer.kt
@@ -51,7 +51,7 @@ class EmbeddedDbInitializer(
     private fun addUser(): Long =
         userController
             .create(
-                UserResources.Request(
+                UserResources.Request.Create(
                     USER_EMAIL,
                     "Lutrogale Otter",
                     false,
@@ -134,7 +134,7 @@ class EmbeddedDbInitializer(
     private fun addProject(): Long =
         projectController
             .create(
-                ProjectResources.Request(
+                ProjectResources.Request.Create(
                     "Otter Project",
                     "This is Sample Project",
                 ),

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/APISpecMigrationControllerTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/APISpecMigrationControllerTest.kt
@@ -29,7 +29,7 @@ class APISpecMigrationControllerTest : FlowTestSupport() {
         projectId =
             projectController
                 .create(
-                    ProjectResources.Request(
+                    ProjectResources.Request.Create(
                         name = "migration",
                         description = "migration test",
                     ),

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerFlow.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerFlow.kt
@@ -35,8 +35,8 @@ internal class UserBulkRegisterControllerFlow(
 
     fun bulkRegister(
         session: Cookie,
-        request: UserResources.BatchRegister.Request,
-    ): List<UserResources.BatchRegister.Result> =
+        request: UserResources.Request.BatchRegister,
+    ): List<UserResources.Reply.BatchRegister> =
         mockMvc
             .post("/v1/maintenance/management/user/batch") {
                 contentType = MediaType.APPLICATION_JSON
@@ -47,13 +47,13 @@ internal class UserBulkRegisterControllerFlow(
             }.andReturn()
             .response
             .contentAsString
-            .fromJson<Replies<UserResources.BatchRegister.Result>>()
+            .fromJson<Replies<UserResources.Reply.BatchRegister>>()
             .getContent()
             .toList()
 
     fun bulkRegisterExpectFail(
         session: Cookie,
-        request: UserResources.BatchRegister.Request,
+        request: UserResources.Request.BatchRegister,
     ): ResultActionsDsl =
         mockMvc.post("/v1/maintenance/management/user/batch") {
             contentType = MediaType.APPLICATION_JSON

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/user/api/UserBulkRegisterControllerTest.kt
@@ -47,7 +47,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
     @Test
     fun `SUPER 어드민이 신규 이메일 목록을 등록하면 모두 SUCCESS를 반환한다`() {
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = listOf("bulk1@test.com", "bulk2@test.com"),
                 projectId = null,
                 authorityDefinitionId = null,
@@ -57,14 +57,14 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
         val results = flow.bulkRegister(superSession, request)
 
         results.size shouldBe 2
-        results.all { it.outcome == UserResources.BatchRegister.Result.Outcome.SUCCESS } shouldBe true
+        results.all { it.outcome == UserResources.Reply.BatchRegister.Outcome.SUCCESS } shouldBe true
         results.all { it.userId != null } shouldBe true
     }
 
     @Test
     fun `이미 등록된 이메일은 SKIPPED를 반환하고 신규 이메일은 SUCCESS를 반환한다`() {
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = listOf(EmbeddedDbInitializer.USER_EMAIL, "new-user@test.com"),
                 projectId = null,
                 authorityDefinitionId = null,
@@ -74,14 +74,14 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
         val results = flow.bulkRegister(superSession, request)
 
         results.size shouldBe 2
-        results.first { it.email == EmbeddedDbInitializer.USER_EMAIL }.outcome shouldBe UserResources.BatchRegister.Result.Outcome.SKIPPED
-        results.first { it.email == "new-user@test.com" }.outcome shouldBe UserResources.BatchRegister.Result.Outcome.SUCCESS
+        results.first { it.email == EmbeddedDbInitializer.USER_EMAIL }.outcome shouldBe UserResources.Reply.BatchRegister.Outcome.SKIPPED
+        results.first { it.email == "new-user@test.com" }.outcome shouldBe UserResources.Reply.BatchRegister.Outcome.SUCCESS
     }
 
     @Test
     fun `전부 중복 이메일이면 전부 SKIPPED를 반환한다`() {
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = listOf(EmbeddedDbInitializer.USER_EMAIL),
                 projectId = null,
                 authorityDefinitionId = null,
@@ -91,7 +91,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
         val results = flow.bulkRegister(superSession, request)
 
         results.size shouldBe 1
-        results.first().outcome shouldBe UserResources.BatchRegister.Result.Outcome.SKIPPED
+        results.first().outcome shouldBe UserResources.Reply.BatchRegister.Outcome.SKIPPED
         results.first().userId shouldBe null
     }
 
@@ -99,7 +99,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
     fun `ALLOW 상태로 등록하고 권한그룹 선택 시 사용자가 생성되고 권한이 부여된다`() {
         val email = "bulk-with-grant@test.com"
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = listOf(email),
                 projectId = projectId,
                 authorityDefinitionId = authorityDefinitionId,
@@ -108,7 +108,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
 
         val results = flow.bulkRegister(superSession, request)
 
-        results.first().outcome shouldBe UserResources.BatchRegister.Result.Outcome.SUCCESS
+        results.first().outcome shouldBe UserResources.Reply.BatchRegister.Outcome.SUCCESS
         val userId = results.first().userId!!
         val user = userRepository.findById(userId).orElseThrow()
         user.status shouldBe User.Status.ALLOW
@@ -119,7 +119,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
     fun `WAIT 상태로 등록하면 사용자만 생성되고 권한은 부여되지 않는다`() {
         val email = "bulk-wait@test.com"
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = listOf(email),
                 projectId = projectId,
                 authorityDefinitionId = authorityDefinitionId,
@@ -128,7 +128,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
 
         val results = flow.bulkRegister(superSession, request)
 
-        results.first().outcome shouldBe UserResources.BatchRegister.Result.Outcome.SUCCESS
+        results.first().outcome shouldBe UserResources.Reply.BatchRegister.Outcome.SUCCESS
         val userId = results.first().userId!!
         val user = userRepository.findById(userId).orElseThrow()
         user.status shouldBe User.Status.WAIT
@@ -141,7 +141,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
         val regularSession = flow.login("regular@bulk-test.com", "pw")
 
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = listOf("some@test.com"),
                 projectId = null,
                 authorityDefinitionId = null,
@@ -156,7 +156,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
     @Test
     fun `이메일 11개를 입력하면 400을 반환한다`() {
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = (1..11).map { "overflow$it@test.com" },
                 projectId = null,
                 authorityDefinitionId = null,
@@ -172,7 +172,7 @@ internal class UserBulkRegisterControllerTest : FlowTestSupport() {
     fun `이름은 이메일 at 앞부분으로 설정된다`() {
         val email = "john.doe@example.com"
         val request =
-            UserResources.BatchRegister.Request(
+            UserResources.Request.BatchRegister(
                 emails = listOf(email),
                 projectId = null,
                 authorityDefinitionId = null,


### PR DESCRIPTION
## Summary

- **swagger-ui ClassNotFoundException** (`javax.xml.bind.annotation.XmlElement`): `jaxb-api:2.3.1` 의존성 추가로 해결 — JDK 11+에서 제거된 `javax.xml.bind`를 `swagger-parser-v2-converter`가 사용하기 때문
- **httpclient5 deprecated API 제거**: `RequestConfig`의 `(long, TimeUnit)` 타임아웃 API → `Timeout.ofMilliseconds()`로 교체, connect timeout을 `ConnectionConfig`로 이동 (httpclient5 5.2+ 권장 패턴)
- **footer 업데이트**: 버전 1.0.0 → 1.0.3, swagger-ui 링크(fa-book 아이콘) 추가
- **`*Resources.kt` @Schema 정리**: `MigrationResources` 누락 어노테이션 추가, `UserResources` DTO 구조를 Request/Reply 그룹 하위로 재편, swagger-ui 참조 오류 해결
- **CLAUDE.md 컨벤션 문서화**: `*Resources.kt` inner class 생성 규칙 및 `@Schema` 네이밍 규칙 추가

## Test plan

- [ ] `./gradlew compileKotlin` 통과 확인
- [ ] 앱 기동 후 `/swagger-ui.html` 접속 — 상단 오류 없음 확인
- [ ] footer에 버전 1.0.3 및 swagger-ui 링크 아이콘 표시 확인