### PR TITLE
feat: add auto-sync management for migration spec URLs

### DIFF
--- a/e2e/tests/dashboard-sync.spec.ts
+++ b/e2e/tests/dashboard-sync.spec.ts
@@ -1,0 +1,194 @@
+import { Page } from '@playwright/test';
+import { test, expect } from '../fixtures/auth';
+
+// DataTable이 페이지네이션으로 특정 행을 숨길 수 있으므로 모든 행을 표시
+async function showAllRows(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as any).$('#dataTables-projects').DataTable().page.len(-1).draw();
+  });
+}
+
+// DataTable reload를 기다리는 waitForResponse + DataTable 전체 표시 헬퍼
+async function waitForTableReloadAndShowAll(page: Page): Promise<void> {
+  await page.waitForResponse(
+    (r) => r.url().includes('/v1/maintenance/projects') && r.status() === 200,
+  );
+  await showAllRows(page);
+}
+
+test.describe('대시보드 자동 Sync 기능', () => {
+  let testProjectId: number;
+
+  test.beforeEach(async ({ adminPage }) => {
+    const res = await adminPage.request.post('/v1/maintenance/project', {
+      data: { name: 'E2E Sync Test', description: 'e2e test', listStructure: 'FLAT' },
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    testProjectId = body.content;
+
+    await adminPage.goto('/dashboard');
+    // DataTable AJAX 초기 로드 대기
+    await adminPage.waitForResponse(
+      (r) => r.url().includes('/v1/maintenance/projects') && r.status() === 200,
+    );
+    await adminPage.waitForSelector('#dataTables-projects tbody tr');
+    await showAllRows(adminPage);
+    // 생성한 프로젝트의 버튼이 DOM에 나타날 때까지 대기
+    await adminPage.waitForSelector(`[data-project-id="${testProjectId}"]`);
+  });
+
+  test('Sync 미설정 프로젝트에 "자동Sync 추가" 버튼이 표시된다', async ({ adminPage }) => {
+    await expect(
+      adminPage.locator(`.btn-sync-add[data-project-id="${testProjectId}"]`),
+    ).toBeVisible();
+  });
+
+  test('"자동Sync 추가" 클릭 시 specType 드롭다운, URL 입력, 테스트·저장 버튼이 있는 모달이 열린다', async ({
+    adminPage,
+  }) => {
+    await adminPage.locator(`.btn-sync-add[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncAddModal.in');
+
+    await expect(adminPage.locator('#sync-add-spec-type')).toBeVisible();
+    await expect(adminPage.locator('#sync-add-url')).toBeVisible();
+    await expect(adminPage.locator('#sync-add-test-btn')).toBeVisible();
+    await expect(adminPage.locator('#sync-add-save-btn')).toBeVisible();
+    // 수정 모달의 "Sync 삭제" 버튼은 등록 모달에 없어야 한다
+    await expect(adminPage.locator('#sync-add-preview-result')).toBeAttached();
+  });
+
+  test('등록 모달은 닫기 버튼으로 닫힌다', async ({ adminPage }) => {
+    await adminPage.locator(`.btn-sync-add[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncAddModal.in');
+
+    await adminPage.click('#syncAddModal button.close');
+    await adminPage.waitForSelector('#syncAddModal', { state: 'hidden' });
+    await expect(adminPage.locator('#syncAddModal')).not.toBeVisible();
+  });
+
+  test('등록 모달 specType 기본값은 OPENAPI_JSON이다', async ({ adminPage }) => {
+    await adminPage.locator(`.btn-sync-add[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncAddModal.in');
+
+    await expect(adminPage.locator('#sync-add-spec-type')).toHaveValue('OPENAPI_JSON');
+  });
+
+  test('Sync 등록 후 해당 프로젝트의 버튼이 "자동 Sync"로 바뀐다', async ({ adminPage }) => {
+    await adminPage.locator(`.btn-sync-add[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncAddModal.in');
+
+    await adminPage.selectOption('#sync-add-spec-type', 'OPENAPI_JSON');
+    await adminPage.fill('#sync-add-url', 'http://example.com/openapi.json');
+
+    await Promise.all([
+      waitForTableReloadAndShowAll(adminPage),
+      adminPage.click('#sync-add-save-btn'),
+    ]);
+    await adminPage.waitForSelector('#syncAddModal', { state: 'hidden' });
+
+    await expect(
+      adminPage.locator(`.btn-sync-edit[data-project-id="${testProjectId}"]`),
+    ).toBeVisible();
+    await expect(
+      adminPage.locator(`.btn-sync-add[data-project-id="${testProjectId}"]`),
+    ).not.toBeAttached();
+  });
+
+  test('"자동 Sync" 클릭 시 기존 specType·URL이 채워진 수정 모달이 열린다', async ({
+    adminPage,
+  }) => {
+    await adminPage.request.post(`/v1/maintenance/project/${testProjectId}/sync`, {
+      data: { specType: 'OPENAPI_YAML', url: 'http://example.com/api.yaml' },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    await adminPage.reload();
+    await adminPage.waitForResponse(
+      (r) => r.url().includes('/v1/maintenance/projects') && r.status() === 200,
+    );
+    await adminPage.waitForSelector('#dataTables-projects tbody tr');
+    await showAllRows(adminPage);
+    await adminPage.waitForSelector(`[data-project-id="${testProjectId}"]`);
+
+    await adminPage.locator(`.btn-sync-edit[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncEditModal.in');
+
+    await expect(adminPage.locator('#sync-edit-spec-type')).toHaveValue('OPENAPI_YAML');
+    await expect(adminPage.locator('#sync-edit-url')).toHaveValue('http://example.com/api.yaml');
+    await expect(adminPage.locator('#sync-edit-test-btn')).toBeVisible();
+    await expect(adminPage.locator('#sync-edit-save-btn')).toBeVisible();
+    await expect(adminPage.locator('#sync-edit-delete-btn')).toBeVisible();
+  });
+
+  test('수정 모달에서 Sync 업데이트 후 변경된 URL이 다시 열면 반영된다', async ({
+    adminPage,
+  }) => {
+    await adminPage.request.post(`/v1/maintenance/project/${testProjectId}/sync`, {
+      data: { specType: 'OPENAPI_JSON', url: 'http://example.com/v1.json' },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    await adminPage.reload();
+    await adminPage.waitForResponse(
+      (r) => r.url().includes('/v1/maintenance/projects') && r.status() === 200,
+    );
+    await adminPage.waitForSelector('#dataTables-projects tbody tr');
+    await showAllRows(adminPage);
+    await adminPage.waitForSelector(`[data-project-id="${testProjectId}"]`);
+
+    // 수정 모달 열기
+    await adminPage.locator(`.btn-sync-edit[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncEditModal.in');
+
+    await adminPage.fill('#sync-edit-url', 'http://example.com/v2.json');
+
+    await Promise.all([
+      waitForTableReloadAndShowAll(adminPage),
+      adminPage.click('#sync-edit-save-btn'),
+    ]);
+    await adminPage.waitForSelector('#syncEditModal', { state: 'hidden' });
+
+    // 다시 열어서 변경된 URL 확인
+    await adminPage.locator(`.btn-sync-edit[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncEditModal.in');
+    await expect(adminPage.locator('#sync-edit-url')).toHaveValue('http://example.com/v2.json');
+  });
+
+  test('수정 모달에서 Sync 삭제 후 "자동Sync 추가" 버튼으로 되돌아온다', async ({
+    adminPage,
+  }) => {
+    await adminPage.request.post(`/v1/maintenance/project/${testProjectId}/sync`, {
+      data: { specType: 'GRAPHQL', url: 'http://example.com/graphql' },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    await adminPage.reload();
+    await adminPage.waitForResponse(
+      (r) => r.url().includes('/v1/maintenance/projects') && r.status() === 200,
+    );
+    await adminPage.waitForSelector('#dataTables-projects tbody tr');
+    await showAllRows(adminPage);
+    await adminPage.waitForSelector(`[data-project-id="${testProjectId}"]`);
+
+    await adminPage.locator(`.btn-sync-edit[data-project-id="${testProjectId}"]`).click();
+    await adminPage.waitForSelector('#syncEditModal.in');
+
+    // confirm 다이얼로그 자동 수락
+    adminPage.once('dialog', (dialog) => dialog.accept());
+
+    await Promise.all([
+      waitForTableReloadAndShowAll(adminPage),
+      adminPage.click('#sync-edit-delete-btn'),
+    ]);
+    await adminPage.waitForSelector('#syncEditModal', { state: 'hidden' });
+
+    await expect(
+      adminPage.locator(`.btn-sync-add[data-project-id="${testProjectId}"]`),
+    ).toBeVisible();
+    await expect(
+      adminPage.locator(`.btn-sync-edit[data-project-id="${testProjectId}"]`),
+    ).not.toBeAttached();
+  });
+});

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/Application.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/Application.kt
@@ -7,7 +7,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 @EnableConfigurationProperties(JdbcSessionProperties::class, AppEnvironment::class)
 @ComponentScan(nameGenerator = FullyQualifiedAnnotationBeanNameGenerator::class)

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/DbInitializer.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/DbInitializer.kt
@@ -7,6 +7,7 @@ import io.mustelidae.otter.lutrogale.web.domain.admin.repository.AdminRepository
 import io.mustelidae.otter.lutrogale.web.domain.authority.api.AuthorityBundleResources
 import io.mustelidae.otter.lutrogale.web.domain.authority.api.AuthorityController
 import io.mustelidae.otter.lutrogale.web.domain.grant.api.UserGrantController
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure
 import io.mustelidae.otter.lutrogale.web.domain.navigation.api.MenuTreeController
 import io.mustelidae.otter.lutrogale.web.domain.navigation.api.MenuTreeResources
 import io.mustelidae.otter.lutrogale.web.domain.project.api.ProjectController
@@ -138,6 +139,7 @@ class DbInitializer(
                 ProjectResources.Request.Create(
                     "Otter Project $timestamp",
                     "This is Sample Project created at $timestamp",
+                    ListStructure.FLAT,
                 ),
             ).content!!
 

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/DummyMenuNavigationRepository.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/DummyMenuNavigationRepository.kt
@@ -1,0 +1,138 @@
+package io.mustelidae.otter.lutrogale.api.domain.migration
+
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+
+/**
+ * Preview 기능을 위한 메모리 기반 더미 MenuNavigation Repository
+ * 실제 데이터베이스에 영향을 주지 않고 메뉴 구조 생성을 시뮬레이션합니다.
+ */
+class DummyMenuNavigationRepository : MenuNavigationRepository {
+    private val storage = mutableListOf<MenuNavigation>()
+    private var idCounter = 1L
+
+    override fun <S : MenuNavigation> save(entity: S): S {
+        if (entity.id == null) {
+            val field = entity.javaClass.getDeclaredField("id")
+            field.isAccessible = true
+            field.set(entity, idCounter++)
+        }
+        storage.removeIf { it.id == entity.id }
+        storage.add(entity)
+        return entity
+    }
+
+    override fun <S : MenuNavigation> saveAll(entities: MutableIterable<S>): MutableList<S> = entities.map { save(it) }.toMutableList()
+
+    override fun findById(id: Long): java.util.Optional<MenuNavigation> = java.util.Optional.ofNullable(storage.find { it.id == id })
+
+    override fun existsById(id: Long): Boolean = storage.any { it.id == id }
+
+    override fun findAll(): MutableList<MenuNavigation> = storage.toMutableList()
+
+    override fun findAllById(ids: MutableIterable<Long>): MutableList<MenuNavigation> = storage.filter { it.id in ids }.toMutableList()
+
+    override fun count(): Long = storage.size.toLong()
+
+    override fun deleteById(id: Long) {
+        storage.removeIf { it.id == id }
+    }
+
+    override fun delete(entity: MenuNavigation) {
+        storage.removeIf { it.id == entity.id }
+    }
+
+    override fun deleteAllById(ids: MutableIterable<Long>) {
+        storage.removeIf { it.id in ids }
+    }
+
+    override fun deleteAll(entities: MutableIterable<MenuNavigation>) {
+        val idsToDelete = entities.mapNotNull { it.id }
+        storage.removeIf { it.id in idsToDelete }
+    }
+
+    override fun deleteAll() {
+        storage.clear()
+    }
+
+    override fun flush() { /* no-op */ }
+
+    override fun <S : MenuNavigation> saveAndFlush(entity: S): S = save(entity)
+
+    override fun <S : MenuNavigation> saveAllAndFlush(entities: MutableIterable<S>): MutableList<S> = saveAll(entities)
+
+    override fun deleteAllInBatch(entities: MutableIterable<MenuNavigation>) = deleteAll(entities)
+
+    override fun deleteAllByIdInBatch(ids: MutableIterable<Long>) = deleteAllById(ids)
+
+    override fun deleteAllInBatch() = deleteAll()
+
+    @Deprecated("Use findById instead")
+    override fun getOne(id: Long): MenuNavigation = findById(id).orElseThrow()
+
+    @Deprecated("Use getReferenceById instead")
+    override fun getById(id: Long): MenuNavigation = findById(id).orElseThrow()
+
+    override fun getReferenceById(id: Long): MenuNavigation = findById(id).orElseThrow()
+
+    override fun <S : MenuNavigation> findAll(example: org.springframework.data.domain.Example<S>): MutableList<S> = mutableListOf()
+
+    override fun <S : MenuNavigation> findAll(
+        example: org.springframework.data.domain.Example<S>,
+        sort: org.springframework.data.domain.Sort,
+    ): MutableList<S> = mutableListOf()
+
+    override fun <S : MenuNavigation> findAll(
+        example: org.springframework.data.domain.Example<S>,
+        pageable: org.springframework.data.domain.Pageable,
+    ): org.springframework.data.domain.Page<S> =
+        org.springframework.data.domain
+            .PageImpl(mutableListOf())
+
+    override fun <S : MenuNavigation> count(example: org.springframework.data.domain.Example<S>): Long = 0
+
+    override fun <S : MenuNavigation> exists(example: org.springframework.data.domain.Example<S>): Boolean = false
+
+    override fun <S : MenuNavigation, R : Any> findBy(
+        example: org.springframework.data.domain.Example<S>,
+        queryFunction: java.util.function.Function<org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery<S>, R>,
+    ): R = throw UnsupportedOperationException("findBy is not supported in dummy repository")
+
+    override fun <S : MenuNavigation> findOne(example: org.springframework.data.domain.Example<S>): java.util.Optional<S> =
+        java.util.Optional.empty()
+
+    override fun findAll(sort: org.springframework.data.domain.Sort): MutableList<MenuNavigation> = storage.toMutableList()
+
+    override fun findAll(pageable: org.springframework.data.domain.Pageable): org.springframework.data.domain.Page<MenuNavigation> =
+        org.springframework.data.domain
+            .PageImpl(storage)
+
+    // MenuNavigationRepository 고유 메서드들
+    override fun findByProjectIdAndId(
+        projectId: Long,
+        nodeId: Long,
+    ): MenuNavigation? = storage.find { it.project?.id == projectId && it.id == nodeId }
+
+    override fun findByProjectIdAndTreeId(
+        projectId: Long,
+        treeId: String,
+    ): MenuNavigation? =
+        storage.find {
+            it.project?.id == projectId && it.treeId == treeId
+        }
+
+    override fun findByStatusTrueAndProjectId(projectId: Long): List<MenuNavigation> =
+        storage.filter {
+            it.status && it.project?.id == projectId
+        }
+
+    override fun findByStatusTrueAndProjectIdAndIdIn(
+        projectId: Long,
+        menuNavigationIds: List<Long>,
+    ): List<MenuNavigation> =
+        storage.filter {
+            it.status && it.project?.id == projectId && it.id in menuNavigationIds
+        }
+
+    override fun findByIdIn(menuNavigationIds: List<Long>): List<MenuNavigation> = storage.filter { it.id in menuNavigationIds }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/GraphQLMigrationInteraction.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/GraphQLMigrationInteraction.kt
@@ -1,14 +1,19 @@
 package io.mustelidae.otter.lutrogale.api.domain.migration
 
 import io.mustelidae.otter.lutrogale.api.domain.migration.client.HttpSpecClient
+import io.mustelidae.otter.lutrogale.api.domain.migration.graphql.FlatBaseGraphQLSyncToMenu
 import io.mustelidae.otter.lutrogale.api.domain.migration.graphql.FlatBasePathToMenu
 import io.mustelidae.otter.lutrogale.api.domain.migration.graphql.HttpOperation
 import io.mustelidae.otter.lutrogale.common.DefaultError
 import io.mustelidae.otter.lutrogale.common.ErrorCode
 import io.mustelidae.otter.lutrogale.config.PolicyException
+import io.mustelidae.otter.lutrogale.config.PreconditionFailException
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure
 import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
 import io.mustelidae.otter.lutrogale.web.domain.project.ProjectFinder
 import io.mustelidae.otter.lutrogale.web.domain.project.ProjectInteraction
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,19 +24,25 @@ class GraphQLMigrationInteraction(
     val projectFinder: ProjectFinder,
     val projectInteraction: ProjectInteraction,
 ) {
-    @Transactional(readOnly = true)
+    private val log = LoggerFactory.getLogger(javaClass)
+
     fun preview(
         url: String,
         httpOperation: HttpOperation,
         headers: List<Pair<String, Any>>?,
     ): String {
-        val projectId = projectInteraction.register("migration", "preview")
-        val project = projectFinder.findBy(projectId)
+        val project =
+            Project.of("migration", "preview", ListStructure.FLAT).apply {
+                addBy(
+                    io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+                        .root(),
+                )
+            }
 
-        val scheme = httpSpecClient.getGraphQLSpec(url, headers)
+        val scheme = httpSpecClient.fetchGraphQLSpec(url, headers)
         val pathToMenu = FlatBasePathToMenu(project, scheme, httpOperation)
 
-        pathToMenu.makeTree(menuNavigationRepository)
+        pathToMenu.makeTree(DummyMenuNavigationRepository())
 
         return pathToMenu.printMenuTree()
     }
@@ -53,11 +64,27 @@ class GraphQLMigrationInteraction(
             )
         }
 
-        val scheme = httpSpecClient.getGraphQLSpec(url, headers)
+        val scheme = httpSpecClient.fetchGraphQLSpec(url, headers)
         val pathToMenu = FlatBasePathToMenu(project, scheme, httpOperation)
 
         pathToMenu.makeTree(menuNavigationRepository)
 
         return menuNavigationRepository.save(pathToMenu.rootMenuNavigation).id!!
+    }
+
+    @Transactional
+    fun sync(projectId: Long) {
+        val project = projectFinder.findBy(projectId)
+        val migrationUrl =
+            project.migrationUrl
+                ?: throw PreconditionFailException("Sync requires a migration spec URL.")
+
+        log.info("Starting GraphQL sync for project: ${project.name}")
+
+        val scheme = httpSpecClient.fetchGraphQLSpec(migrationUrl, null)
+        val syncToMenu = FlatBaseGraphQLSyncToMenu(project, scheme)
+        syncToMenu.makeTree(menuNavigationRepository)
+
+        log.info("Completed GraphQL sync for project: ${project.name}")
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/OpenAPIMigrationInteraction.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/OpenAPIMigrationInteraction.kt
@@ -5,15 +5,22 @@ import io.mustelidae.otter.lutrogale.api.domain.migration.api.MigrationResources
 import io.mustelidae.otter.lutrogale.api.domain.migration.api.MigrationResources.Request.OpenAPI.MigrationType.TREE
 import io.mustelidae.otter.lutrogale.api.domain.migration.client.HttpSpecClient
 import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.FlatBasePathToMenu
+import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.FlatBaseSyncToMenu
 import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.SwaggerSpec
 import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.TreeBasePathToMenu
+import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.TreeBaseSyncToMenu
 import io.mustelidae.otter.lutrogale.common.DefaultError
 import io.mustelidae.otter.lutrogale.common.ErrorCode
+import io.mustelidae.otter.lutrogale.config.DevelopMistakeException
 import io.mustelidae.otter.lutrogale.config.PolicyException
+import io.mustelidae.otter.lutrogale.config.PreconditionFailException
 import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure
 import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
 import io.mustelidae.otter.lutrogale.web.domain.project.ProjectFinder
 import io.mustelidae.otter.lutrogale.web.domain.project.ProjectInteraction
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -24,19 +31,27 @@ class OpenAPIMigrationInteraction(
     val projectFinder: ProjectFinder,
     private val projectInteraction: ProjectInteraction,
 ) {
-    @Transactional(readOnly = true)
+    private val log = LoggerFactory.getLogger(javaClass)
+
     fun preview(
         url: String,
         swaggerSpecType: SwaggerSpec.Type,
         migrationType: MigrationResources.Request.OpenAPI.MigrationType,
         headers: List<Pair<String, Any>>?,
     ): String {
-        val projectId = projectInteraction.register("migration", "preview")
-        val project = projectFinder.findBy(projectId)
+        val listStructure =
+            when (migrationType) {
+                FLAT -> ListStructure.FLAT
+                TREE -> ListStructure.TREE
+            }
+        val project =
+            Project.of("migration", "preview", listStructure).apply {
+                addBy(MenuNavigation.root())
+            }
         val rootMenuNavigation = project.menuNavigations.first()
 
         val pathToMenu: PathToMenu = pathToMenuUsingOpenAPI(url, swaggerSpecType, headers, migrationType, rootMenuNavigation)
-        pathToMenu.makeTree(menuNavigationRepository)
+        pathToMenu.makeTree(DummyMenuNavigationRepository())
 
         return pathToMenu.printMenuTree()
     }
@@ -74,14 +89,42 @@ class OpenAPIMigrationInteraction(
         migrationType: MigrationResources.Request.OpenAPI.MigrationType,
         rootMenuNavigation: MenuNavigation,
     ): PathToMenu {
-        val openAPIJson = httpSpecClient.getOpenAPISpec(url, swaggerSpecType, headers)
+        val openAPIJson = httpSpecClient.fetchOpenAPISpec(url, swaggerSpecType, headers)
         val swaggerSpec = SwaggerSpec(openAPIJson, swaggerSpecType)
 
-        val pathToMenu: PathToMenu =
-            when (migrationType) {
-                TREE -> TreeBasePathToMenu(swaggerSpec.openAPI, rootMenuNavigation)
-                FLAT -> FlatBasePathToMenu(swaggerSpec.openAPI, rootMenuNavigation)
+        return when (migrationType) {
+            TREE -> TreeBasePathToMenu(swaggerSpec.openAPI, rootMenuNavigation)
+            FLAT -> FlatBasePathToMenu(swaggerSpec.openAPI, rootMenuNavigation)
+        }
+    }
+
+    @Transactional
+    fun sync(projectId: Long) {
+        val project = projectFinder.findBy(projectId)
+        val migrationUrl =
+            project.migrationUrl
+                ?: throw PreconditionFailException("Sync requires a migration spec URL.")
+
+        log.info("Starting OpenAPI sync for project: ${project.name}")
+
+        val swaggerSpecType =
+            when (project.specType) {
+                Project.SpecType.OPENAPI_JSON -> SwaggerSpec.Type.JSON
+                Project.SpecType.OPENAPI_YAML -> SwaggerSpec.Type.YAML
+                else -> throw DevelopMistakeException("Unexpected specType for OpenAPI sync: ${project.specType}")
             }
-        return pathToMenu
+
+        val spec = httpSpecClient.fetchOpenAPISpec(migrationUrl, swaggerSpecType, null)
+        val swaggerSpec = SwaggerSpec(spec, swaggerSpecType)
+        val rootMenuNavigation = project.menuNavigations.first { it.isRoot() }
+
+        val syncToMenu =
+            when (project.listStructure) {
+                ListStructure.FLAT -> FlatBaseSyncToMenu(swaggerSpec.openAPI, rootMenuNavigation)
+                ListStructure.TREE -> TreeBaseSyncToMenu(swaggerSpec.openAPI, rootMenuNavigation)
+            }
+        syncToMenu.makeTree(menuNavigationRepository)
+
+        log.info("Completed OpenAPI sync for project: ${project.name}")
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/APISpecMigrationController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/APISpecMigrationController.kt
@@ -6,6 +6,8 @@ import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.SwaggerSpec
 import io.mustelidae.otter.lutrogale.common.Reply
 import io.mustelidae.otter.lutrogale.common.toReply
 import io.mustelidae.otter.lutrogale.web.common.annotation.LoginCheck
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import io.mustelidae.otter.lutrogale.web.domain.project.ProjectInteraction
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PathVariable
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 class APISpecMigrationController(
     private val openAPIMigrationInteraction: OpenAPIMigrationInteraction,
     private val graphQLMigrationInteraction: GraphQLMigrationInteraction,
+    private val projectInteraction: ProjectInteraction,
 ) {
     @PostMapping("/openapi/preview")
     @ResponseStatus(HttpStatus.OK)
@@ -30,10 +33,7 @@ class APISpecMigrationController(
     ): Reply<String> {
         val swaggerSpecType = SwaggerSpec.Type.valueOf(request.format.name)
         val header = request.header?.map { it.key to it.value }?.toList()
-
-        val preview = openAPIMigrationInteraction.preview(request.url, swaggerSpecType, request.migrationType, header)
-
-        return preview.toReply()
+        return openAPIMigrationInteraction.preview(request.url, swaggerSpecType, request.migrationType, header).toReply()
     }
 
     @PostMapping("/openapi/generate/project/{projectId}")
@@ -44,9 +44,22 @@ class APISpecMigrationController(
     ): Reply<Long> {
         val swaggerSpecType = SwaggerSpec.Type.valueOf(request.format.name)
         val header = request.header?.map { it.key to it.value }?.toList()
+        return openAPIMigrationInteraction.generate(projectId, request.url, swaggerSpecType, request.migrationType, header).toReply()
+    }
 
-        val rootMenuId = openAPIMigrationInteraction.generate(projectId, request.url, swaggerSpecType, request.migrationType, header)
-        return rootMenuId.toReply()
+    @PostMapping("/openapi/sync/project/{projectId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun syncOpenAPI(
+        @PathVariable projectId: Long,
+        @RequestBody request: MigrationResources.Request.OpenAPISync,
+    ): Reply<String> {
+        val specType =
+            when (request.format) {
+                MigrationResources.Request.OpenAPI.OpenAPIFormat.JSON -> Project.SpecType.OPENAPI_JSON
+                MigrationResources.Request.OpenAPI.OpenAPIFormat.YAML -> Project.SpecType.OPENAPI_YAML
+            }
+        projectInteraction.startSyncSpec(projectId, specType, request.url)
+        return "Sync configured successfully".toReply()
     }
 
     @PostMapping("/graphql/preview")
@@ -55,10 +68,7 @@ class APISpecMigrationController(
         @RequestBody request: MigrationResources.Request.GraphQL,
     ): Reply<String> {
         val header = request.header?.map { it.key to it.value }?.toList()
-
-        val preview = graphQLMigrationInteraction.preview(request.url, request.httpOperation, header)
-
-        return preview.toReply()
+        return graphQLMigrationInteraction.preview(request.url, request.httpOperation, header).toReply()
     }
 
     @PostMapping("/graphql/generate/project/{projectId}")
@@ -68,8 +78,16 @@ class APISpecMigrationController(
         @RequestBody request: MigrationResources.Request.GraphQL,
     ): Reply<Long> {
         val header = request.header?.map { it.key to it.value }?.toList()
+        return graphQLMigrationInteraction.generate(projectId, request.url, request.httpOperation, header).toReply()
+    }
 
-        val rootMenuId = graphQLMigrationInteraction.generate(projectId, request.url, request.httpOperation, header)
-        return rootMenuId.toReply()
+    @PostMapping("/graphql/sync/project/{projectId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun syncGraphQL(
+        @PathVariable projectId: Long,
+        @RequestBody request: MigrationResources.Request.GraphQLSync,
+    ): Reply<String> {
+        projectInteraction.startSyncSpec(projectId, Project.SpecType.GRAPHQL, request.url)
+        return "Sync configured successfully".toReply()
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/MigrationResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/api/MigrationResources.kt
@@ -30,11 +30,22 @@ class MigrationResources {
             }
         }
 
+        @Schema(name = "Lutrogale.Migration.Request.OpenAPISync")
+        data class OpenAPISync(
+            val url: String,
+            val format: OpenAPI.OpenAPIFormat,
+        )
+
         @Schema(name = "Lutrogale.Migration.Request.GraphQL")
         data class GraphQL(
             val url: String,
             val httpOperation: HttpOperation,
             val header: List<HttpHeader>? = null,
+        )
+
+        @Schema(name = "Lutrogale.Migration.Request.GraphQLSync")
+        data class GraphQLSync(
+            val url: String,
         )
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/DummyHttpSpecClient.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/DummyHttpSpecClient.kt
@@ -3,7 +3,7 @@ package io.mustelidae.otter.lutrogale.api.domain.migration.client
 import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.SwaggerSpec
 
 class DummyHttpSpecClient : HttpSpecClient {
-    override fun getOpenAPISpec(
+    override fun fetchOpenAPISpec(
         url: String,
         type: SwaggerSpec.Type,
         headers: List<Pair<String, Any>>?,
@@ -22,7 +22,7 @@ class DummyHttpSpecClient : HttpSpecClient {
             }
         }
 
-    override fun getGraphQLSpec(
+    override fun fetchGraphQLSpec(
         url: String,
         headers: List<Pair<String, Any>>?,
     ): String = TWEET_GRAPHQL

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/HttpSpecClient.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/HttpSpecClient.kt
@@ -3,13 +3,13 @@ package io.mustelidae.otter.lutrogale.api.domain.migration.client
 import io.mustelidae.otter.lutrogale.api.domain.migration.openapi.SwaggerSpec
 
 interface HttpSpecClient {
-    fun getOpenAPISpec(
+    fun fetchOpenAPISpec(
         url: String,
         type: SwaggerSpec.Type,
         headers: List<Pair<String, Any>>?,
     ): String
 
-    fun getGraphQLSpec(
+    fun fetchGraphQLSpec(
         url: String,
         headers: List<Pair<String, Any>>?,
     ): String

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/StableHttpSpecClient.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/StableHttpSpecClient.kt
@@ -30,7 +30,7 @@ class StableHttpSpecClient(
      * @param headers 요청에 추가할 헤더들 list.
      * @return API 스펙의 String 표현값.
      */
-    override fun getOpenAPISpec(
+    override fun fetchOpenAPISpec(
         url: String,
         type: SwaggerSpec.Type,
         headers: List<Pair<String, Any>>?,
@@ -59,7 +59,7 @@ class StableHttpSpecClient(
      * @param headers 요청에 추가할 헤더들 list.
      * @return API 스펙의 String 표현값.
      */
-    override fun getGraphQLSpec(
+    override fun fetchGraphQLSpec(
         url: String,
         headers: List<Pair<String, Any>>?,
     ): String {

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/graphql/FlatBaseGraphQLSyncToMenu.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/graphql/FlatBaseGraphQLSyncToMenu.kt
@@ -1,0 +1,170 @@
+package io.mustelidae.otter.lutrogale.api.domain.migration.graphql
+
+import graphql.language.ObjectTypeDefinition
+import graphql.schema.idl.SchemaParser
+import io.mustelidae.otter.lutrogale.api.domain.migration.PathToMenu
+import io.mustelidae.otter.lutrogale.common.Constant
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.RequestMethod
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * GraphQL 스키마를 동기화하여 메뉴 구조로 변환하는 클래스입니다.
+ * 기존 메뉴와 새로운 스키마를 비교하여 추가/만료 처리를 수행합니다.
+ *
+ * @property project 메뉴 네비게이션과 연관된 프로젝트입니다.
+ * @property scheme GraphQL 스키마 문자열입니다.
+ */
+class FlatBaseGraphQLSyncToMenu(
+    val project: Project,
+    private val scheme: String,
+) : PathToMenu {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override var rootMenuNavigation: MenuNavigation = project.menuNavigations.first()
+
+    /**
+     * GraphQL 스키마를 분석하여 기존 메뉴와 동기화합니다.
+     * 새로운 필드는 추가하고, 스키마에 없는 기존 메뉴는 만료 처리합니다.
+     *
+     * @param menuNavigationRepository MenuNavigation 엔티티들과 상호작용하기 위해 사용되는 저장소
+     */
+    override fun makeTree(menuNavigationRepository: MenuNavigationRepository) {
+        try {
+            log.info("Starting GraphQL sync for project: ${project.name}")
+
+            // 1. scheme에서 필드 정보 추출
+            val schemeFields = extractFieldsFromScheme()
+
+            // 2. 기존 메뉴 네비게이션 리스트 (root 제외)
+            val existingMenus = project.menuNavigations.filter { !it.isRoot() && it.status }
+            val existingMenuKeys = existingMenus.map { "${it.methodType}_${it.uriBlock}" }.toSet()
+
+            // 3. 기존 메뉴 네비게이션 리스트에 없는 scheme를 찾아 신규 추가
+            val newFields = schemeFields.filter { "${it.method}_${it.fieldName}" !in existingMenuKeys }
+            newFields.forEach { fieldInfo ->
+                addNewMenuNavigation(fieldInfo, menuNavigationRepository)
+            }
+
+            // 4. 기존 메뉴 네비게이션 리스트에는 있는데 scheme가 없는 경우 해당 메뉴 네비게이션 expire
+            val schemeMenuKeys = schemeFields.map { "${it.method}_${it.fieldName}" }.toSet()
+            val menusToExpire = existingMenus.filter { "${it.methodType}_${it.uriBlock}" !in schemeMenuKeys }
+            menusToExpire.forEach { menu ->
+                log.info("Expiring menu: ${menu.name} as it's not found in scheme")
+                menu.expire()
+                menuNavigationRepository.save(menu)
+            }
+
+            log.info("Successfully synced project: ${project.name}, added ${newFields.size} menus, expired ${menusToExpire.size} menus")
+        } catch (e: Exception) {
+            log.debug("Exception details for sync failure in project ${project.name}: ${e.message}", e)
+            log.error("Failed to sync project: ${project.name}, error: ${e.message}", e)
+            throw e
+        }
+    }
+
+    private fun extractFieldsFromScheme(): List<FieldInfo> {
+        val fieldInfos = mutableListOf<FieldInfo>()
+
+        // 기존 메뉴 네비게이션의 treeId에서 마지막 번호 추출
+        val existingTreeIds =
+            project.menuNavigations
+                .mapNotNull { menu ->
+                    val treeId = menu.treeId
+                    if (treeId.startsWith("j${rootMenuNavigation.treeId}_")) {
+                        treeId.substringAfter("j${rootMenuNavigation.treeId}_").toIntOrNull()
+                    } else {
+                        null
+                    }
+                }
+
+        val startNumber =
+            if (existingTreeIds.isNotEmpty()) {
+                existingTreeIds.maxOf { it } + 1
+            } else {
+                1
+            }
+
+        val atomicInt = AtomicInteger(startNumber)
+
+        try {
+            val typeDefinitionRegistry = SchemaParser().parse(scheme)
+            val types = typeDefinitionRegistry.types()
+
+            // Query 필드 처리
+            val query = types["Query"] as? ObjectTypeDefinition
+            query?.fieldDefinitions?.forEach { field ->
+                fieldInfos.add(
+                    FieldInfo(
+                        name = field.description?.content ?: "[${RequestMethod.GET}] ${transformName(field.name)}",
+                        fieldName = field.name,
+                        type = "Query",
+                        method = RequestMethod.GET,
+                        treeId = "j${rootMenuNavigation.treeId}_${atomicInt.getAndIncrement()}",
+                    ),
+                )
+            }
+
+            // Mutation 필드 처리
+            val mutation = types["Mutation"] as? ObjectTypeDefinition
+            mutation?.fieldDefinitions?.forEach { field ->
+                fieldInfos.add(
+                    FieldInfo(
+                        name = field.description?.content ?: "[${RequestMethod.POST}] ${transformName(field.name)}",
+                        fieldName = field.name,
+                        type = "Mutation",
+                        method = RequestMethod.POST,
+                        treeId = "j${rootMenuNavigation.treeId}_${atomicInt.getAndIncrement()}",
+                    ),
+                )
+            }
+        } catch (e: Exception) {
+            log.error("Failed to parse GraphQL scheme: ${e.message}", e)
+            throw e
+        }
+
+        return fieldInfos
+    }
+
+    private fun addNewMenuNavigation(
+        fieldInfo: FieldInfo,
+        menuNavigationRepository: MenuNavigationRepository,
+    ) {
+        val menuNavigation =
+            MenuNavigation(
+                name = fieldInfo.name,
+                type = Constant.NavigationType.FUNCTION,
+                uriBlock = fieldInfo.fieldName,
+                methodType = fieldInfo.method,
+                treeId = fieldInfo.treeId,
+                parentTreeId = rootMenuNavigation.treeId,
+            ).also {
+                it.setBy(project)
+                it.setBy(rootMenuNavigation)
+            }
+
+        menuNavigationRepository.save(menuNavigation)
+        log.info("Added new menu navigation: ${fieldInfo.name}")
+    }
+
+    override fun printMenuTree(): String {
+        val prettyPrint = StringBuilder()
+
+        rootMenuNavigation.menuNavigations.forEach {
+            prettyPrint.append("${it.uriBlock} ${it.methodType}\n")
+        }
+
+        return prettyPrint.toString()
+    }
+
+    private data class FieldInfo(
+        val name: String,
+        val fieldName: String,
+        val type: String,
+        val method: RequestMethod,
+        val treeId: String,
+    )
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/FlatBaseSyncToMenu.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/FlatBaseSyncToMenu.kt
@@ -1,0 +1,75 @@
+package io.mustelidae.otter.lutrogale.api.domain.migration.openapi
+
+import io.mustelidae.otter.lutrogale.api.domain.migration.PathToMenu
+import io.mustelidae.otter.lutrogale.common.Constant
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import io.swagger.v3.oas.models.OpenAPI
+import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+class FlatBaseSyncToMenu(
+    openAPI: OpenAPI,
+    override var rootMenuNavigation: MenuNavigation,
+) : PathToMenu {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val pathWithHttpMethods: List<HttpAPISpec> = PathCollector(openAPI).collectPathAndMethods()
+    private val project: Project = rootMenuNavigation.project!!
+
+    override fun makeTree(menuNavigationRepository: MenuNavigationRepository) {
+        val existingMenus = project.menuNavigations.filter { !it.isRoot() && it.status }
+        val existingMenuKeys = existingMenus.map { "${it.methodType}_${it.uriBlock}" }.toSet()
+
+        val specMenuKeys =
+            pathWithHttpMethods
+                .flatMap { spec ->
+                    spec.methods.map { method -> "${method}_${spec.url}" }
+                }.toSet()
+
+        val maxSeq =
+            existingMenus
+                .mapNotNull { menu ->
+                    menu.treeId
+                        .takeIf { it.startsWith("j${rootMenuNavigation.treeId}_") }
+                        ?.substringAfter("j${rootMenuNavigation.treeId}_")
+                        ?.toIntOrNull()
+                }.maxOrNull() ?: 0
+        val atomicInt = AtomicInteger(maxSeq + 1)
+
+        pathWithHttpMethods.forEach { spec ->
+            spec.methods.forEach { method ->
+                if ("${method}_${spec.url}" !in existingMenuKeys) {
+                    val newMenu =
+                        MenuNavigation(
+                            spec.summary ?: "[$method] ${transformName(spec.url)}",
+                            Constant.NavigationType.FUNCTION,
+                            spec.url,
+                            method,
+                            "j${rootMenuNavigation.treeId}_${atomicInt.getAndIncrement()}",
+                            rootMenuNavigation.treeId,
+                        ).also {
+                            it.setBy(project)
+                            it.setBy(rootMenuNavigation)
+                        }
+                    menuNavigationRepository.save(newMenu)
+                    log.info("Sync: added ${spec.url} [$method]")
+                }
+            }
+        }
+
+        existingMenus
+            .filter { "${it.methodType}_${it.uriBlock}" !in specMenuKeys }
+            .forEach { menu ->
+                menu.expire()
+                menuNavigationRepository.save(menu)
+                log.info("Sync: expired ${menu.uriBlock} [${menu.methodType}]")
+            }
+    }
+
+    override fun printMenuTree(): String {
+        val sb = StringBuilder()
+        rootMenuNavigation.menuNavigations.forEach { sb.append("${it.uriBlock} ${it.methodType}\n") }
+        return sb.toString()
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/SwaggerSpec.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/SwaggerSpec.kt
@@ -6,12 +6,17 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.parser.OpenAPIV3Parser
 import io.swagger.v3.parser.converter.SwaggerConverter
 import io.swagger.v3.parser.core.models.ParseOptions
+import org.slf4j.LoggerFactory
 import org.springframework.data.util.Version
 
 class SwaggerSpec(
     private val originalSpec: String,
     val type: Type,
 ) {
+    companion object {
+        private val log = LoggerFactory.getLogger(SwaggerSpec::class.java)
+    }
+
     val openAPI: OpenAPI
 
     init {
@@ -36,6 +41,7 @@ class SwaggerSpec(
                         val treeNode = Jackson.getMapper().readTree(originalSpec)
                         treeNode.get("swagger") ?: treeNode.get("openapi")
                     } catch (e: Exception) {
+                        log.debug("Failed to parse JSON OpenAPI spec: ${e.message}", e)
                         throw IllegalStateException("The format of the Open API Spec is not Json Type.", e)
                     }
                 }
@@ -45,6 +51,7 @@ class SwaggerSpec(
                         val treeNode = Jackson.getYmlMapper().readTree(originalSpec)
                         treeNode.get("swagger") ?: treeNode.get("openapi")
                     } catch (e: Exception) {
+                        log.debug("Failed to parse YAML OpenAPI spec: ${e.message}", e)
                         throw IllegalStateException("The format of the Open API Spec is not YAML Type.", e)
                     }
                 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/TreeBaseSyncToMenu.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/TreeBaseSyncToMenu.kt
@@ -1,0 +1,167 @@
+package io.mustelidae.otter.lutrogale.api.domain.migration.openapi
+
+import io.mustelidae.otter.lutrogale.api.domain.migration.PathToMenu
+import io.mustelidae.otter.lutrogale.common.Constant
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import io.swagger.v3.oas.models.OpenAPI
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.RequestMethod
+import java.util.concurrent.atomic.AtomicInteger
+
+class TreeBaseSyncToMenu(
+    openAPI: OpenAPI,
+    override var rootMenuNavigation: MenuNavigation,
+) : PathToMenu {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val pathWithHttpMethods: List<HttpAPISpec> = PathCollector(openAPI).collectPathAndMethods()
+    private val project: Project = rootMenuNavigation.project!!
+    private val atomicInt = AtomicInteger(1)
+
+    override fun makeTree(menuNavigationRepository: MenuNavigationRepository) {
+        val maxSeq =
+            project.menuNavigations
+                .mapNotNull { menu ->
+                    menu.treeId
+                        .takeIf { it.startsWith("j${rootMenuNavigation.treeId}_") }
+                        ?.substringAfter("j${rootMenuNavigation.treeId}_")
+                        ?.toIntOrNull()
+                }.maxOrNull() ?: 0
+        atomicInt.set(maxSeq + 1)
+
+        val sortedPaths = pathWithHttpMethods.sortedBy { it.url }
+
+        for (apiSpec in sortedPaths) {
+            addTree(rootMenuNavigation, apiSpec, menuNavigationRepository)
+        }
+
+        expireRemovedFromTree(rootMenuNavigation, sortedPaths, 0, menuNavigationRepository)
+    }
+
+    private fun addTree(
+        parentMenuNavigation: MenuNavigation,
+        apiSpec: HttpAPISpec,
+        menuNavigationRepository: MenuNavigationRepository,
+    ) {
+        val urlParts = apiSpec.getUrlParts()
+        var current = parentMenuNavigation
+
+        for ((index, part) in urlParts.withIndex()) {
+            var child =
+                current.menuNavigations.find {
+                    it.uriBlock == "/$part" && it.methodType == RequestMethod.GET && it.status
+                }
+
+            if (child == null) {
+                val type =
+                    when (index) {
+                        0 -> Constant.NavigationType.CATEGORY
+                        1 -> Constant.NavigationType.MENU
+                        else -> Constant.NavigationType.FUNCTION
+                    }
+                val name = if (index == 0) apiSpec.summary ?: "[GET] ${transformName(part)}" else "[GET] ${transformName(part)}"
+                val newMenu =
+                    MenuNavigation(
+                        name,
+                        type,
+                        "/$part",
+                        RequestMethod.GET,
+                        "j${rootMenuNavigation.treeId}_${atomicInt.getAndIncrement()}",
+                        current.treeId,
+                    ).also { it.setBy(project) }
+                menuNavigationRepository.save(newMenu)
+                current.addBy(newMenu)
+                child = newMenu
+            }
+
+            if (index == urlParts.lastIndex) {
+                for (method in apiSpec.methods) {
+                    if (method == RequestMethod.GET) continue
+                    val exists = current.menuNavigations.any { it.uriBlock == "/$part" && it.methodType == method && it.status }
+                    if (!exists) {
+                        val newMenu =
+                            MenuNavigation(
+                                "[$method] ${transformName(part)}",
+                                Constant.NavigationType.FUNCTION,
+                                "/$part",
+                                method,
+                                "j${rootMenuNavigation.treeId}_${atomicInt.getAndIncrement()}",
+                                current.treeId,
+                            ).also { it.setBy(project) }
+                        menuNavigationRepository.save(newMenu)
+                        current.addBy(newMenu)
+                    }
+                }
+            }
+
+            current = child
+        }
+    }
+
+    /**
+     * 재귀적으로 기존 트리를 순회하면서 새 스펙에 없는 노드를 만료시킨다.
+     * GET 노드(경로 세그먼트)가 새 스펙에 없으면 해당 노드와 모든 하위 노드를 만료한다.
+     */
+    private fun expireRemovedFromTree(
+        node: MenuNavigation,
+        activeSpecs: List<HttpAPISpec>,
+        depth: Int,
+        menuNavigationRepository: MenuNavigationRepository,
+    ) {
+        for (child in node.menuNavigations.toList()) {
+            if (!child.status) continue
+
+            val segment = child.uriBlock.removePrefix("/")
+            val specsWithSegment =
+                activeSpecs.filter { spec ->
+                    spec.getUrlParts().getOrNull(depth) == segment
+                }
+
+            if (child.methodType == RequestMethod.GET) {
+                if (specsWithSegment.isEmpty()) {
+                    expireSubtree(child, menuNavigationRepository)
+                } else {
+                    expireRemovedFromTree(child, specsWithSegment, depth + 1, menuNavigationRepository)
+                }
+            } else {
+                // 비-GET 메서드 노드: 같은 경로 세그먼트에서 이 메서드가 여전히 존재하는지 확인
+                val hasMethod = specsWithSegment.any { child.methodType in it.methods }
+                if (!hasMethod) {
+                    child.expire()
+                    menuNavigationRepository.save(child)
+                    log.info("Sync: expired ${child.uriBlock} [${child.methodType}]")
+                }
+            }
+        }
+    }
+
+    private fun expireSubtree(
+        node: MenuNavigation,
+        menuNavigationRepository: MenuNavigationRepository,
+    ) {
+        for (child in node.menuNavigations.toList()) {
+            if (child.status) expireSubtree(child, menuNavigationRepository)
+        }
+        node.expire()
+        menuNavigationRepository.save(node)
+        log.info("Sync: expired subtree node ${node.uriBlock} [${node.methodType}]")
+    }
+
+    override fun printMenuTree(): String {
+        val sb = StringBuilder()
+        printTree(sb, rootMenuNavigation, 0)
+        return sb.toString()
+    }
+
+    private fun printTree(
+        print: StringBuilder,
+        menuNavigation: MenuNavigation,
+        depth: Int,
+    ) {
+        if (menuNavigation.uriBlock != "/") {
+            print.append("${"    ".repeat(depth)}- ${menuNavigation.uriBlock} (${menuNavigation.methodType})\n")
+        }
+        menuNavigation.menuNavigations.forEach { printTree(print, it, depth + 1) }
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/scheduler/ProjectSpecSyncScheduler.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/scheduler/ProjectSpecSyncScheduler.kt
@@ -1,0 +1,45 @@
+package io.mustelidae.otter.lutrogale.api.domain.migration.scheduler
+
+import io.mustelidae.otter.lutrogale.api.domain.migration.GraphQLMigrationInteraction
+import io.mustelidae.otter.lutrogale.api.domain.migration.OpenAPIMigrationInteraction
+import io.mustelidae.otter.lutrogale.config.redis.distributedlock.DistributedLock
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import io.mustelidae.otter.lutrogale.web.domain.project.ProjectFinder
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class ProjectSpecSyncScheduler(
+    private val projectFinder: ProjectFinder,
+    private val openAPIMigrationInteraction: OpenAPIMigrationInteraction,
+    private val graphQLMigrationInteraction: GraphQLMigrationInteraction,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelay = 5 * 60 * 1000L)
+    @DistributedLock(qualifier = "project-spec-sync")
+    fun syncAll() {
+        val projects = projectFinder.findAllBySyncEnabled()
+        if (projects.isEmpty()) return
+
+        log.info("Sync scheduler: syncing ${projects.size} project(s)")
+
+        for (project in projects) {
+            val projectId = project.id!!
+            try {
+                when (project.specType) {
+                    Project.SpecType.GRAPHQL -> graphQLMigrationInteraction.sync(projectId)
+
+                    Project.SpecType.OPENAPI_JSON,
+                    Project.SpecType.OPENAPI_YAML,
+                    -> openAPIMigrationInteraction.sync(projectId)
+
+                    null -> log.warn("Project '${project.name}' has syncEnabled=true but no specType configured")
+                }
+            } catch (e: Exception) {
+                log.error("Failed to sync project '${project.name}': ${e.message}", e)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/CLAUDE.md
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/CLAUDE.md
@@ -122,4 +122,8 @@ class IdBaseAuthorizedKey(
   - TTL: 5분
   - GraphQL 엔드포인트도 내부적으로 URI로 변환(`/{operation}`)되어 이 키를 사용함
 
+- **`DistributedLockKey`** — `config/redis/distributedlock/`
+  - Key: `lutrogale:distributed-lock:{qualifier}`
+  - TTL: 어노테이션 `leaseTime` 파라미터로 결정 (기본 10분)
+
 > **주의**: 새 Key 클래스를 추가하면 이 목록에 반드시 등록한다.

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLock.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLock.kt
@@ -1,0 +1,11 @@
+package io.mustelidae.otter.lutrogale.config.redis.distributedlock
+
+import java.util.concurrent.TimeUnit
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DistributedLock(
+    val qualifier: String,
+    val leaseTime: Long = 10L,
+    val timeUnit: TimeUnit = TimeUnit.MINUTES,
+)

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLockAspect.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLockAspect.kt
@@ -1,0 +1,85 @@
+package io.mustelidae.otter.lutrogale.config.redis.distributedlock
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.UUID
+
+@Aspect
+@Component
+class DistributedLockAspect(
+    private val redisTemplate: StringRedisTemplate,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val unlockScript =
+        DefaultRedisScript(
+            """
+            if redis.call('get', KEYS[1]) == ARGV[1] then
+                return redis.call('del', KEYS[1])
+            else
+                return 0
+            end
+            """.trimIndent(),
+            Long::class.java,
+        )
+
+    // Parameter name "distributedLock" must match the pointcut expression to bind the annotation instance
+    @Around("@annotation(distributedLock)")
+    fun around(
+        pjp: ProceedingJoinPoint,
+        distributedLock: DistributedLock,
+    ): Any? {
+        val key = DistributedLockKey(distributedLock.qualifier).getKey()
+        val lockValue = UUID.randomUUID().toString()
+        val duration = DistributedLockKey.toDuration(distributedLock.leaseTime, distributedLock.timeUnit)
+
+        val acquired = tryAcquire(key, lockValue, duration)
+
+        if (acquired == null) {
+            log.warn("Redis 연결 실패로 분산락을 건너뜁니다. key={}", key)
+            return pjp.proceed()
+        }
+
+        if (!acquired) {
+            log.info("분산락 획득 실패, 실행을 건너뜁니다. key={}", key)
+            return null
+        }
+
+        log.debug("분산락 획득. key={}", key)
+        try {
+            return pjp.proceed()
+        } finally {
+            release(key, lockValue)
+        }
+    }
+
+    /** @return true=획득 성공, false=다른 서버 점유 중, null=Redis 오류 */
+    private fun tryAcquire(
+        key: String,
+        lockValue: String,
+        duration: Duration,
+    ): Boolean? =
+        try {
+            redisTemplate.opsForValue().setIfAbsent(key, lockValue, duration)
+        } catch (e: Exception) {
+            log.warn("Redis 락 획득 중 오류. key={}", key, e)
+            null
+        }
+
+    private fun release(
+        key: String,
+        lockValue: String,
+    ) {
+        try {
+            redisTemplate.execute(unlockScript, listOf(key), lockValue)
+        } catch (e: Exception) {
+            log.warn("Redis 락 해제 중 오류. key={}", key, e)
+        }
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLockKey.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLockKey.kt
@@ -1,0 +1,18 @@
+package io.mustelidae.otter.lutrogale.config.redis.distributedlock
+
+import io.mustelidae.otter.lutrogale.config.redis.RedisKey
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+class DistributedLockKey(
+    private val qualifier: String,
+) : RedisKey {
+    override fun getKey(): String = "${RedisKey.PREFIX}:distributed-lock:$qualifier"
+
+    companion object {
+        fun toDuration(
+            leaseTime: Long,
+            timeUnit: TimeUnit,
+        ): Duration = Duration.of(leaseTime, timeUnit.toChronoUnit())
+    }
+}

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/navigation/MenuNavigation.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/navigation/MenuNavigation.kt
@@ -102,11 +102,22 @@ class MenuNavigation(
     }
 
     fun expire() {
+        if (isRoot()) {
+            throw IllegalStateException("최상위 navigation은 expire할 수 없습니다.")
+        }
+
         val userPersonalGrants: List<UserPersonalGrant> = this.userPersonalGrants
         userPersonalGrants.forEach {
             it.expire()
         }
         status = false
+    }
+
+    fun isRoot(): Boolean = treeId == "1" && parentTreeId == "#"
+
+    enum class ListStructure {
+        TREE,
+        FLAT,
     }
 
     companion object {

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/Project.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/Project.kt
@@ -7,6 +7,8 @@ import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -16,6 +18,7 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.annotations.SQLRestriction
 import org.hibernate.envers.Audited
+import org.hibernate.envers.NotAudited
 import org.hibernate.envers.RelationTargetAuditMode
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -31,8 +34,13 @@ class Project(
     var name: String,
     @Column(length = 500)
     var description: String? = null,
+    @NotAudited
     @Column(length = 100)
     var apiKey: String,
+    @NotAudited
+    @Enumerated(EnumType.STRING)
+    @Column(name = "list_structure", length = 10)
+    var listStructure: MenuNavigation.ListStructure,
 ) : Audit() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,6 +48,18 @@ class Project(
         protected set
 
     var status = true
+        protected set
+
+    @Column(name = "spec_type", length = 50)
+    var specType: SpecType? = null
+        protected set
+
+    @Column(name = "migration_url", length = 500)
+    var migrationUrl: String? = null
+        protected set
+
+    @Column(name = "sync_enabled")
+    var syncEnabled: Boolean = false
         protected set
 
     @SQLRestriction("status = true")
@@ -64,6 +84,21 @@ class Project(
         status = false
     }
 
+    fun setSync(
+        spec: SpecType,
+        url: String,
+    ) {
+        specType = spec
+        migrationUrl = url
+        syncEnabled = true
+    }
+
+    fun removeSync() {
+        specType = null
+        migrationUrl = null
+        syncEnabled = false
+    }
+
     fun addBy(menuNavigation: MenuNavigation) {
         menuNavigations.add(menuNavigation)
         if (this != menuNavigation.project) {
@@ -78,10 +113,17 @@ class Project(
         }
     }
 
+    enum class SpecType {
+        OPENAPI_JSON,
+        OPENAPI_YAML,
+        GRAPHQL,
+    }
+
     companion object {
         fun of(
             name: String,
             description: String?,
+            listStructure: MenuNavigation.ListStructure,
         ): Project {
             val time: Long =
                 LocalDateTime
@@ -93,6 +135,7 @@ class Project(
                 name,
                 description,
                 Crypto.sha256(name + time),
+                listStructure,
             )
         }
     }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/ProjectFinder.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/ProjectFinder.kt
@@ -41,6 +41,8 @@ class ProjectFinder(
         return project
     }
 
+    fun findAllBySyncEnabled(): List<Project> = projectRepository.findBySyncEnabledTrue()
+
     fun findAllByIncludeNavigationsProject(id: Long): List<ReplyOfMenuNavigation> {
         val project = findByLive(id)
 

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/ProjectInteraction.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/ProjectInteraction.kt
@@ -1,6 +1,8 @@
 package io.mustelidae.otter.lutrogale.web.domain.project
 
+import io.mustelidae.otter.lutrogale.config.PreconditionFailException
 import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure
 import io.mustelidae.otter.lutrogale.web.domain.project.repository.ProjectRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,14 +14,43 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class ProjectInteraction(
     private val projectRepository: ProjectRepository,
+    private val projectFinder: ProjectFinder,
 ) {
     fun register(
         name: String,
         description: String?,
+        listStructure: ListStructure? = ListStructure.TREE,
     ): Long {
-        val project = Project.of(name, description)
+        val project = Project.of(name, description, listStructure ?: ListStructure.TREE)
         val menuNavigation = MenuNavigation.root()
         project.addBy(menuNavigation)
         return projectRepository.save(project).id!!
+    }
+
+    fun registerSyncSpec(
+        projectId: Long,
+        spec: Project.SpecType,
+        migrationUrl: String,
+    ) {
+        val project = projectFinder.findBy(projectId)
+        if (project.syncEnabled) throw PreconditionFailException("이미 Sync가 설정된 프로젝트입니다.")
+        project.setSync(spec, migrationUrl)
+        projectRepository.save(project)
+    }
+
+    fun startSyncSpec(
+        projectId: Long,
+        spec: Project.SpecType,
+        migrationUrl: String,
+    ) {
+        val project = projectFinder.findBy(projectId)
+        project.setSync(spec, migrationUrl)
+        projectRepository.save(project)
+    }
+
+    fun stopSyncSpec(projectId: Long) {
+        val project = projectFinder.findBy(projectId)
+        project.removeSync()
+        projectRepository.save(project)
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectController.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectController.kt
@@ -4,6 +4,7 @@ import io.mustelidae.otter.lutrogale.common.Replies
 import io.mustelidae.otter.lutrogale.common.Reply
 import io.mustelidae.otter.lutrogale.common.toReplies
 import io.mustelidae.otter.lutrogale.common.toReply
+import io.mustelidae.otter.lutrogale.config.DataNotFindException
 import io.mustelidae.otter.lutrogale.web.common.annotation.LoginCheck
 import io.mustelidae.otter.lutrogale.web.domain.navigation.api.NavigationResources.Reply.ReplyOfMenuNavigation
 import io.mustelidae.otter.lutrogale.web.domain.project.ProjectFinder
@@ -12,12 +13,16 @@ import io.mustelidae.otter.lutrogale.web.domain.user.UserFinder
 import io.mustelidae.otter.lutrogale.web.domain.user.api.UserResources
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "프로젝트")
@@ -39,10 +44,11 @@ class ProjectController(
 
     @Operation(summary = "프로젝트 추가")
     @PostMapping("/project")
+    @ResponseStatus(HttpStatus.CREATED)
     fun create(
         @RequestBody request: ProjectResources.Request.Create,
     ): Reply<Long> {
-        val id = projectInteraction.register(request.name, request.description)
+        val id = projectInteraction.register(request.name, request.description, request.listStructure)
         return id.toReply()
     }
 
@@ -81,4 +87,46 @@ class ProjectController(
         projectFinder
             .findAllByIncludeNavigationsProject(id)
             .toReplies()
+
+    @Operation(summary = "자동 Sync 정보 조회")
+    @GetMapping("/project/{id}/sync")
+    fun getSyncInfo(
+        @PathVariable id: Long,
+    ): Reply<ProjectResources.Reply.SyncInfo> {
+        val project = projectFinder.findBy(id)
+        if (!project.syncEnabled) throw DataNotFindException("Sync가 설정되지 않았습니다.")
+        return ProjectResources.Reply.SyncInfo
+            .from(project)
+            .toReply()
+    }
+
+    @Operation(summary = "자동 Sync 등록")
+    @PostMapping("/project/{id}/sync")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun registerSync(
+        @PathVariable id: Long,
+        @RequestBody request: ProjectResources.Request.RegisterSync,
+    ): Reply<Unit> {
+        projectInteraction.registerSyncSpec(id, request.specType, request.url)
+        return Unit.toReply()
+    }
+
+    @Operation(summary = "자동 Sync 업데이트")
+    @PutMapping("/project/{id}/sync")
+    fun updateSync(
+        @PathVariable id: Long,
+        @RequestBody request: ProjectResources.Modify.UpdateSync,
+    ): Reply<Unit> {
+        projectInteraction.startSyncSpec(id, request.specType, request.url)
+        return Unit.toReply()
+    }
+
+    @Operation(summary = "자동 Sync 삭제")
+    @DeleteMapping("/project/{id}/sync")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteSync(
+        @PathVariable id: Long,
+    ) {
+        projectInteraction.stopSyncSpec(id)
+    }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectResources.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectResources.kt
@@ -1,6 +1,7 @@
 package io.mustelidae.otter.lutrogale.web.domain.project.api
 
 import io.mustelidae.otter.lutrogale.utils.toDateString
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure
 import io.mustelidae.otter.lutrogale.web.domain.project.Project
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -10,6 +11,21 @@ class ProjectResources {
         data class Create(
             val name: String,
             val description: String,
+            val listStructure: ListStructure? = null,
+        )
+
+        @Schema(name = "Lutrogale.Project.Request.RegisterSync")
+        data class RegisterSync(
+            val specType: Project.SpecType,
+            val url: String,
+        )
+    }
+
+    class Modify {
+        @Schema(name = "Lutrogale.Project.Modify.UpdateSync")
+        data class UpdateSync(
+            val specType: Project.SpecType,
+            val url: String,
         )
     }
 
@@ -21,6 +37,9 @@ class ProjectResources {
         val created: String,
         val status: Boolean,
         val description: String? = null,
+        val syncEnabled: Boolean = false,
+        val specType: Project.SpecType? = null,
+        val migrationUrl: String? = null,
     ) {
         companion object {
             fun from(project: Project): Reply =
@@ -32,8 +51,25 @@ class ProjectResources {
                         createdAt!!.toDateString(),
                         status,
                         description,
+                        syncEnabled,
+                        specType,
+                        migrationUrl,
                     )
                 }
+        }
+
+        @Schema(name = "Lutrogale.Project.Reply.SyncInfo")
+        data class SyncInfo(
+            val specType: Project.SpecType,
+            val url: String,
+        ) {
+            companion object {
+                fun from(project: Project): SyncInfo =
+                    SyncInfo(
+                        specType = project.specType!!,
+                        url = project.migrationUrl!!,
+                    )
+            }
         }
     }
 }

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/repository/ProjectRepository.kt
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ProjectRepository : JpaRepository<Project, Long> {
     fun findByApiKey(apiKey: String): Project?
+
+    fun findBySyncEnabledTrue(): List<Project>
 }

--- a/src/main/resources/static/dist/js/route.js
+++ b/src/main/resources/static/dist/js/route.js
@@ -68,6 +68,10 @@ var OsoriRoute = (function () {
     map.set("project.findOne",          "/v1/maintenance/project/{id}");
     map.set("project.findUsersProject", "/v1/maintenance/project/{id}/users");
     map.set("project.findNavigationsProject", "/v1/maintenance/project/{id}/navigations");
+    map.set("project.sync",             "/v1/maintenance/project/{id}/sync");
+
+    map.set("migration.openapi.preview",  "/v1/migration/openapi/preview");
+    map.set("migration.graphql.preview",  "/v1/migration/graphql/preview");
 
 
     var findBy = function (name) {

--- a/src/main/resources/templates/dashboard.ftl
+++ b/src/main/resources/templates/dashboard.ftl
@@ -55,9 +55,192 @@
                 </div>
 			</section>
 		</@layout.baseWrapper>
+
+        <!-- 자동 Sync 추가 모달 -->
+        <div class="modal fade" id="syncAddModal" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
+                        <h4 class="modal-title">자동 Sync 추가</h4>
+                    </div>
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <label>Spec 타입</label>
+                            <select id="sync-add-spec-type" class="form-control">
+                                <option value="OPENAPI_JSON">OpenAPI (JSON)</option>
+                                <option value="OPENAPI_YAML">OpenAPI (YAML)</option>
+                                <option value="GRAPHQL">GraphQL</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label>Spec URL</label>
+                            <input type="text" id="sync-add-url" class="form-control" placeholder="https://example.com/openapi.json">
+                        </div>
+                        <div class="form-group">
+                            <label>테스트 결과</label>
+                            <pre id="sync-add-preview-result" class="pre-scrollable" style="min-height:80px; background:#f4f4f4; padding:8px; border-radius:4px; font-size:12px; white-space:pre-wrap;"></pre>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">닫기</button>
+                        <button type="button" class="btn btn-info" id="sync-add-test-btn">테스트</button>
+                        <button type="button" class="btn btn-primary" id="sync-add-save-btn">저장하기</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 자동 Sync 조회/수정 모달 -->
+        <div class="modal fade" id="syncEditModal" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
+                        <h4 class="modal-title">자동 Sync 설정</h4>
+                    </div>
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <label>Spec 타입</label>
+                            <select id="sync-edit-spec-type" class="form-control">
+                                <option value="OPENAPI_JSON">OpenAPI (JSON)</option>
+                                <option value="OPENAPI_YAML">OpenAPI (YAML)</option>
+                                <option value="GRAPHQL">GraphQL</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label>Spec URL</label>
+                            <input type="text" id="sync-edit-url" class="form-control" placeholder="https://example.com/openapi.json">
+                        </div>
+                        <div class="form-group">
+                            <label>테스트 결과</label>
+                            <pre id="sync-edit-preview-result" class="pre-scrollable" style="min-height:80px; background:#f4f4f4; padding:8px; border-radius:4px; font-size:12px; white-space:pre-wrap;"></pre>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-danger pull-left" id="sync-edit-delete-btn">Sync 삭제</button>
+                        <button type="button" class="btn btn-default" data-dismiss="modal">닫기</button>
+                        <button type="button" class="btn btn-info" id="sync-edit-test-btn">테스트</button>
+                        <button type="button" class="btn btn-primary" id="sync-edit-save-btn">저장하기</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <script src="/static/plugins/datatables/jquery.dataTables.js"></script>
         <script src="/static/plugins/datatables/dataTables.bootstrap.min.js"></script>
         <script>
+            var currentSyncProjectId = null;
+
+            function buildPreviewPayload(specType, url) {
+                if (specType === 'GRAPHQL') {
+                    return {
+                        endpoint: OsoriRoute.getUri('migration.graphql.preview'),
+                        data: { url: url, httpOperation: 'ONLY_POST' }
+                    };
+                } else {
+                    return {
+                        endpoint: OsoriRoute.getUri('migration.openapi.preview'),
+                        data: {
+                            url: url,
+                            version: '',
+                            format: specType === 'OPENAPI_YAML' ? 'YAML' : 'JSON',
+                            migrationType: 'FLAT'
+                        }
+                    };
+                }
+            }
+
+            function runPreview(specType, url, resultElementId) {
+                var payload = buildPreviewPayload(specType, url);
+                var $result = $('#' + resultElementId);
+                $result.text('테스트 중...');
+                AJAX.postData(payload.endpoint, payload.data)
+                    .done(function(res) {
+                        $result.text(res.content || '(응답 없음)');
+                    })
+                    .fail(function(xhr) {
+                        $result.text('오류: ' + (xhr.responseJSON && xhr.responseJSON.message ? xhr.responseJSON.message : xhr.status));
+                    });
+            }
+
+            // 자동 Sync 추가 모달
+            $(document).on('click', '.btn-sync-add', function() {
+                currentSyncProjectId = $(this).data('project-id');
+                $('#sync-add-spec-type').val('OPENAPI_JSON');
+                $('#sync-add-url').val('');
+                $('#sync-add-preview-result').text('');
+                $('#syncAddModal').modal('show');
+            });
+
+            $('#sync-add-test-btn').on('click', function() {
+                var specType = $('#sync-add-spec-type').val();
+                var url = $('#sync-add-url').val().trim();
+                if (!url) { alert('URL을 입력하세요.'); return; }
+                runPreview(specType, url, 'sync-add-preview-result');
+            });
+
+            $('#sync-add-save-btn').on('click', function() {
+                var specType = $('#sync-add-spec-type').val();
+                var url = $('#sync-add-url').val().trim();
+                if (!url) { alert('URL을 입력하세요.'); return; }
+                var apiUrl = OsoriRoute.getUri('project.sync', { id: currentSyncProjectId });
+                AJAX.postData(apiUrl, { specType: specType, url: url })
+                    .done(function() {
+                        $('#syncAddModal').modal('hide');
+                        $('#dataTables-projects').DataTable().ajax.reload();
+                    })
+                    .fail(function(xhr) {
+                        alert('저장 실패: ' + (xhr.responseJSON && xhr.responseJSON.message ? xhr.responseJSON.message : xhr.status));
+                    });
+            });
+
+            // 자동 Sync 조회/수정 모달
+            $(document).on('click', '.btn-sync-edit', function() {
+                currentSyncProjectId = $(this).data('project-id');
+                var specType = $(this).data('spec-type');
+                var migrationUrl = $(this).data('migration-url');
+                $('#sync-edit-spec-type').val(specType);
+                $('#sync-edit-url').val(migrationUrl);
+                $('#sync-edit-preview-result').text('');
+                $('#syncEditModal').modal('show');
+            });
+
+            $('#sync-edit-test-btn').on('click', function() {
+                var specType = $('#sync-edit-spec-type').val();
+                var url = $('#sync-edit-url').val().trim();
+                if (!url) { alert('URL을 입력하세요.'); return; }
+                runPreview(specType, url, 'sync-edit-preview-result');
+            });
+
+            $('#sync-edit-save-btn').on('click', function() {
+                var specType = $('#sync-edit-spec-type').val();
+                var url = $('#sync-edit-url').val().trim();
+                if (!url) { alert('URL을 입력하세요.'); return; }
+                var apiUrl = OsoriRoute.getUri('project.sync', { id: currentSyncProjectId });
+                AJAX.putData(apiUrl, { specType: specType, url: url })
+                    .done(function() {
+                        $('#syncEditModal').modal('hide');
+                        $('#dataTables-projects').DataTable().ajax.reload();
+                    })
+                    .fail(function(xhr) {
+                        alert('저장 실패: ' + (xhr.responseJSON && xhr.responseJSON.message ? xhr.responseJSON.message : xhr.status));
+                    });
+            });
+
+            $('#sync-edit-delete-btn').on('click', function() {
+                if (!confirm('자동 Sync 설정을 삭제하시겠습니까?')) return;
+                var apiUrl = OsoriRoute.getUri('project.sync', { id: currentSyncProjectId });
+                AJAX.deleteData(apiUrl)
+                    .done(function() {
+                        $('#syncEditModal').modal('hide');
+                        $('#dataTables-projects').DataTable().ajax.reload();
+                    })
+                    .fail(function(xhr) {
+                        alert('삭제 실패: ' + (xhr.responseJSON && xhr.responseJSON.message ? xhr.responseJSON.message : xhr.status));
+                    });
+            });
+
             var opt = {
                 "ajax": {
                     "url": OsoriRoute.getUri("project.findAll"),
@@ -70,7 +253,25 @@
                     {"title": "프로젝트명", "data": "name"},
                     {"title": "설명", "data": "description"},
                     {"title": "API KEY", "data": "apiKey"},
-                    {"title": "생성일", "data": "created"}
+                    {"title": "생성일", "data": "created"},
+                    {
+                        "title": "자동 Sync",
+                        "data": null,
+                        "orderable": false,
+                        "render": function(data, type, row) {
+                            if (row.syncEnabled) {
+                                return '<button class="btn btn-xs btn-success btn-sync-edit"' +
+                                    ' data-project-id="' + row.id + '"' +
+                                    ' data-spec-type="' + row.specType + '"' +
+                                    ' data-migration-url="' + _.escape(row.migrationUrl) + '">' +
+                                    '자동 Sync</button>';
+                            } else {
+                                return '<button class="btn btn-xs btn-primary btn-sync-add"' +
+                                    ' data-project-id="' + row.id + '">' +
+                                    '자동Sync 추가</button>';
+                            }
+                        }
+                    }
                 ]
             };
 

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/StableHttpSpecClientTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/client/StableHttpSpecClientTest.kt
@@ -21,7 +21,7 @@ class StableHttpSpecClientTest {
             )
         val stableRestStyleMigrationClient = StableHttpSpecClient(RestClient.new(env), true)
         val openAPISpec =
-            stableRestStyleMigrationClient.getOpenAPISpec(
+            stableRestStyleMigrationClient.fetchOpenAPISpec(
                 "https://petstore.swagger.io/v2/swagger.json",
                 SwaggerSpec.Type.JSON,
                 null,
@@ -42,7 +42,7 @@ class StableHttpSpecClientTest {
                 1000,
             )
         val stableHttpSpecClient = StableHttpSpecClient(RestClient.new(env), true)
-        val openAPISpec = stableHttpSpecClient.getOpenAPISpec("https://petstore.swagger.io/v2/swagger.yaml", SwaggerSpec.Type.YAML, null)
+        val openAPISpec = stableHttpSpecClient.fetchOpenAPISpec("https://petstore.swagger.io/v2/swagger.yaml", SwaggerSpec.Type.YAML, null)
 
         assertNotNull(openAPISpec)
     }
@@ -59,7 +59,7 @@ class StableHttpSpecClientTest {
             )
         val stableHttpSpecClient = StableHttpSpecClient(RestClient.new(env), true)
         val graphQLSpec =
-            stableHttpSpecClient.getGraphQLSpec(
+            stableHttpSpecClient.fetchGraphQLSpec(
                 "https://raw.githubusercontent.com/marmelab/GraphQL-example/refs/heads/master/schema.graphql",
                 null,
             )

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/graphql/FlatBasePathToMenuTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/graphql/FlatBasePathToMenuTest.kt
@@ -16,7 +16,7 @@ class FlatBasePathToMenuTest {
         val schema = DummyHttpSpecClient.TWEET_GRAPHQL
         val rootMenuNavigation = MenuNavigation.root()
         val project =
-            Project("gql test", null, "").apply {
+            Project("gql test", null, "", io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure.FLAT).apply {
                 addBy(rootMenuNavigation)
             }
         val menuNavigationRepository: MenuNavigationRepository = mockk()
@@ -36,7 +36,7 @@ class FlatBasePathToMenuTest {
         val schema = DummyHttpSpecClient.TWEET_GRAPHQL
         val rootMenuNavigation = MenuNavigation.root()
         val project =
-            Project("gql test", null, "").apply {
+            Project("gql test", null, "", io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure.FLAT).apply {
                 addBy(rootMenuNavigation)
             }
         val menuNavigationRepository: MenuNavigationRepository = mockk()
@@ -55,7 +55,7 @@ class FlatBasePathToMenuTest {
         val schema = DummyHttpSpecClient.TWEET_GRAPHQL
         val rootMenuNavigation = MenuNavigation.root()
         val project =
-            Project("gql test", null, "").apply {
+            Project("gql test", null, "", io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure.FLAT).apply {
                 addBy(rootMenuNavigation)
             }
         val menuNavigationRepository: MenuNavigationRepository = mockk()

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/FlatBasePathToMenuTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/FlatBasePathToMenuTest.kt
@@ -26,7 +26,7 @@ class FlatBasePathToMenuTest {
 
         val root =
             MenuNavigation.root().apply {
-                setBy(Project("migration", null, ""))
+                setBy(Project("migration", null, "", io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure.FLAT))
             }
 
         val menuNavigationRepository: MenuNavigationRepository = mockk()

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/FlatBaseSyncToMenuTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/FlatBaseSyncToMenuTest.kt
@@ -1,0 +1,203 @@
+package io.mustelidae.otter.lutrogale.api.domain.migration.openapi
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mustelidae.otter.lutrogale.common.Constant
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure
+import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.Paths
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.bind.annotation.RequestMethod
+
+class FlatBaseSyncToMenuTest {
+    private lateinit var root: MenuNavigation
+    private lateinit var project: Project
+    private lateinit var repo: MenuNavigationRepository
+
+    @BeforeEach
+    fun setUp() {
+        root = MenuNavigation.root()
+        project = Project("test", null, "test-key", ListStructure.FLAT).apply { addBy(root) }
+        repo = mockk()
+        every { repo.save(any()) } returns MenuNavigation.root()
+    }
+
+    @Test
+    fun `spec에 신규 API가 있으면 MenuNavigation이 추가된다`() {
+        addExistingMenu("/users", RequestMethod.GET)
+
+        val openAPI =
+            buildOpenAPI(
+                "/users" to listOf(RequestMethod.GET),
+                "/orders" to listOf(RequestMethod.POST),
+            )
+
+        FlatBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        val activeMenus = activeMenusOf(project)
+        activeMenus.size shouldBe 2
+        activeMenus.any { it.uriBlock == "/orders" && it.methodType == RequestMethod.POST } shouldBe true
+    }
+
+    @Test
+    fun `spec에서 사라진 API의 MenuNavigation은 만료된다`() {
+        addExistingMenu("/users", RequestMethod.GET)
+        val toBeExpired = addExistingMenu("/orders", RequestMethod.POST)
+
+        val openAPI =
+            buildOpenAPI(
+                "/users" to listOf(RequestMethod.GET),
+            )
+
+        FlatBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        toBeExpired.status shouldBe false
+        activeMenusOf(project).size shouldBe 1
+    }
+
+    @Test
+    fun `이미 만료된 API가 spec에 다시 나타나면 새로 생성된다`() {
+        addExistingMenu("/users", RequestMethod.GET)
+        val expiredMenu = addExistingMenu("/orders", RequestMethod.GET).also { it.expire() }
+
+        val openAPI =
+            buildOpenAPI(
+                "/users" to listOf(RequestMethod.GET),
+                "/orders" to listOf(RequestMethod.GET),
+            )
+
+        FlatBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        val activeMenus = activeMenusOf(project)
+        activeMenus.size shouldBe 2
+        activeMenus.any { it.uriBlock == "/orders" && it != expiredMenu } shouldBe true
+        expiredMenu.status shouldBe false
+    }
+
+    @Test
+    fun `spec과 기존 MenuNavigation이 동일하면 변경이 없다`() {
+        addExistingMenu("/users", RequestMethod.GET)
+        addExistingMenu("/orders", RequestMethod.POST)
+
+        val openAPI =
+            buildOpenAPI(
+                "/users" to listOf(RequestMethod.GET),
+                "/orders" to listOf(RequestMethod.POST),
+            )
+
+        FlatBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        verify(exactly = 0) { repo.save(any()) }
+        activeMenusOf(project).size shouldBe 2
+    }
+
+    @Test
+    fun `같은 경로의 메서드 추가와 삭제는 독립적으로 처리된다`() {
+        addExistingMenu("/users", RequestMethod.GET)
+        val toBeExpired = addExistingMenu("/users", RequestMethod.POST)
+
+        // POST 삭제, DELETE 추가
+        val openAPI =
+            buildOpenAPI(
+                "/users" to listOf(RequestMethod.GET, RequestMethod.DELETE),
+            )
+
+        FlatBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        toBeExpired.status shouldBe false
+        val activeMenus = activeMenusOf(project)
+        activeMenus.size shouldBe 2
+        activeMenus.any { it.uriBlock == "/users" && it.methodType == RequestMethod.GET } shouldBe true
+        activeMenus.any { it.uriBlock == "/users" && it.methodType == RequestMethod.DELETE } shouldBe true
+    }
+
+    @Test
+    fun `기존 메뉴가 없는 상태에서 spec을 적용하면 모두 신규 생성된다`() {
+        val openAPI =
+            buildOpenAPI(
+                "/users" to listOf(RequestMethod.GET, RequestMethod.POST),
+                "/orders" to listOf(RequestMethod.GET),
+            )
+
+        FlatBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        activeMenusOf(project).size shouldBe 3
+    }
+
+    @Test
+    fun `spec이 빈 경우 기존 MenuNavigation이 모두 만료된다`() {
+        val a = addExistingMenu("/users", RequestMethod.GET)
+        val b = addExistingMenu("/orders", RequestMethod.POST)
+
+        FlatBaseSyncToMenu(OpenAPI().paths(Paths()), root).makeTree(repo)
+
+        a.status shouldBe false
+        b.status shouldBe false
+        activeMenusOf(project).size shouldBe 0
+    }
+
+    // --- helpers ---
+
+    private fun addExistingMenu(
+        uriBlock: String,
+        method: RequestMethod,
+    ): MenuNavigation {
+        val seq = project.menuNavigations.size
+        return MenuNavigation(
+            "[$method] $uriBlock",
+            Constant.NavigationType.FUNCTION,
+            uriBlock,
+            method,
+            "j1_$seq",
+            "1",
+        ).also {
+            it.setBy(project)
+            it.setBy(root)
+        }
+    }
+
+    private fun activeMenusOf(project: Project) = project.menuNavigations.filter { !it.isRoot() && it.status }
+
+    private fun buildOpenAPI(vararg pathAndMethods: Pair<String, List<RequestMethod>>): OpenAPI {
+        val paths = Paths()
+        for ((url, methods) in pathAndMethods) {
+            val pathItem = PathItem().summary(url)
+            for (method in methods) {
+                val op = Operation()
+                when (method) {
+                    RequestMethod.GET -> {
+                        pathItem.get(op)
+                    }
+
+                    RequestMethod.POST -> {
+                        pathItem.post(op)
+                    }
+
+                    RequestMethod.PUT -> {
+                        pathItem.put(op)
+                    }
+
+                    RequestMethod.DELETE -> {
+                        pathItem.delete(op)
+                    }
+
+                    RequestMethod.PATCH -> {
+                        pathItem.patch(op)
+                    }
+
+                    else -> {}
+                }
+            }
+            paths.addPathItem(url, pathItem)
+        }
+        return OpenAPI().paths(paths)
+    }
+}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/TreeBasePathToMenuTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/TreeBasePathToMenuTest.kt
@@ -26,7 +26,7 @@ class TreeBasePathToMenuTest {
 
         val root =
             MenuNavigation.root().apply {
-                setBy(Project("migration", null, ""))
+                setBy(Project("migration", null, "", io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure.TREE))
             }
         val treeBasePathToMenu = TreeBasePathToMenu(specs, root)
         val menuNavigationRepository: MenuNavigationRepository = mockk()

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/TreeBaseSyncToMenuTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/api/domain/migration/openapi/TreeBaseSyncToMenuTest.kt
@@ -1,0 +1,242 @@
+package io.mustelidae.otter.lutrogale.api.domain.migration.openapi
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation
+import io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure
+import io.mustelidae.otter.lutrogale.web.domain.navigation.repository.MenuNavigationRepository
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.PathItem
+import io.swagger.v3.oas.models.Paths
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.web.bind.annotation.RequestMethod
+
+class TreeBaseSyncToMenuTest {
+    private lateinit var root: MenuNavigation
+    private lateinit var project: Project
+    private lateinit var repo: MenuNavigationRepository
+
+    @BeforeEach
+    fun setUp() {
+        root = MenuNavigation.root()
+        project = Project("test", null, "test-key", ListStructure.TREE).apply { addBy(root) }
+        repo = mockk()
+        every { repo.save(any()) } returns MenuNavigation.root()
+    }
+
+    @Test
+    fun `spec에 신규 경로가 추가되면 트리 노드가 생성된다`() {
+        // 초기: GET /users
+        setupTree(HttpAPISpec("/users", listOf(RequestMethod.GET), null))
+
+        // 신규: GET /orders 추가
+        val openAPI =
+            buildOpenAPI(
+                "/users" to listOf(RequestMethod.GET),
+                "/orders" to listOf(RequestMethod.GET),
+            )
+
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        val activeRootChildren = root.menuNavigations.filter { it.status }
+        activeRootChildren.size shouldBe 2
+        activeRootChildren.any { it.uriBlock == "/orders" && it.methodType == RequestMethod.GET } shouldBe true
+    }
+
+    @Test
+    fun `spec에서 비-GET 메서드가 사라지면 해당 노드만 만료되고 GET 노드는 유지된다`() {
+        // 초기: GET /users/:id, POST /users/:id
+        setupTree(HttpAPISpec("/users/:id", listOf(RequestMethod.GET, RequestMethod.POST), null))
+
+        // POST 제거
+        val openAPI = buildOpenAPI("/users/:id" to listOf(RequestMethod.GET))
+
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        val usersNode = root.menuNavigations.first { it.uriBlock == "/users" && it.methodType == RequestMethod.GET }
+        val idGetNode = usersNode.menuNavigations.firstOrNull { it.uriBlock == "/:id" && it.methodType == RequestMethod.GET }
+        val idPostNode = usersNode.menuNavigations.firstOrNull { it.uriBlock == "/:id" && it.methodType == RequestMethod.POST }
+
+        usersNode.status shouldBe true
+        idGetNode?.status shouldBe true
+        idPostNode?.status shouldBe false
+    }
+
+    @Test
+    fun `spec에서 상위 경로가 사라지면 하위 노드 전체가 cascade 만료된다`() {
+        // 초기: GET /users/profiles, GET /orders/items
+        setupTree(
+            HttpAPISpec("/users/profiles", listOf(RequestMethod.GET), null),
+            HttpAPISpec("/orders/items", listOf(RequestMethod.GET), null),
+        )
+
+        // orders 전체 제거
+        val openAPI = buildOpenAPI("/users/profiles" to listOf(RequestMethod.GET))
+
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        val ordersNode = root.menuNavigations.firstOrNull { it.uriBlock == "/orders" }
+        ordersNode?.status shouldBe false
+        ordersNode?.menuNavigations?.forEach { it.status shouldBe false }
+
+        val usersNode = root.menuNavigations.first { it.uriBlock == "/users" }
+        usersNode.status shouldBe true
+    }
+
+    @Test
+    fun `spec이 줄어들어도 남아있는 경로의 노드는 유지된다`() {
+        // 초기: GET /api/users/profiles, GET /api/users/settings
+        setupTree(
+            HttpAPISpec("/api/users/profiles", listOf(RequestMethod.GET), null),
+            HttpAPISpec("/api/users/settings", listOf(RequestMethod.GET), null),
+        )
+
+        // settings 제거
+        val openAPI = buildOpenAPI("/api/users/profiles" to listOf(RequestMethod.GET))
+
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        val apiNode = root.menuNavigations.first { it.uriBlock == "/api" }
+        val usersNode = apiNode.menuNavigations.first { it.uriBlock == "/users" }
+        val profilesNode = usersNode.menuNavigations.first { it.uriBlock == "/profiles" }
+        val settingsNode = usersNode.menuNavigations.first { it.uriBlock == "/settings" }
+
+        apiNode.status shouldBe true
+        usersNode.status shouldBe true
+        profilesNode.status shouldBe true
+        settingsNode.status shouldBe false
+    }
+
+    @Test
+    fun `spec이 전부 빈 경우 기존 트리 전체가 만료된다`() {
+        setupTree(
+            HttpAPISpec("/users/profiles", listOf(RequestMethod.GET), null),
+            HttpAPISpec("/orders", listOf(RequestMethod.GET, RequestMethod.POST), null),
+        )
+
+        TreeBaseSyncToMenu(OpenAPI().paths(Paths()), root).makeTree(repo)
+
+        root.menuNavigations.filter { it.status }.size shouldBe 0
+    }
+
+    @Test
+    fun `이미 만료된 노드는 재만료 처리 없이 건너뛴다`() {
+        setupTree(HttpAPISpec("/users", listOf(RequestMethod.GET), null))
+        val usersNode = root.menuNavigations.first { it.uriBlock == "/users" }
+
+        val expiredNode =
+            MenuNavigation(
+                "legacy",
+                io.mustelidae.otter.lutrogale.common.Constant.NavigationType.CATEGORY,
+                "/legacy",
+                RequestMethod.GET,
+                "j1_99",
+                "1",
+            ).also {
+                it.setBy(project)
+                it.setBy(root)
+                it.expire()
+            }
+
+        val openAPI = buildOpenAPI("/users" to listOf(RequestMethod.GET))
+
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        usersNode.status shouldBe true
+        expiredNode.status shouldBe false
+        verify(exactly = 0) { repo.save(expiredNode) }
+    }
+
+    @Test
+    fun `expire된 경로가 spec에 다시 나타나면 신규 노드로 생성된다`() {
+        setupTree(HttpAPISpec("/users", listOf(RequestMethod.GET), null))
+        val expiredUsersNode = root.menuNavigations.first { it.uriBlock == "/users" }
+        expiredUsersNode.expire()
+
+        val openAPI = buildOpenAPI("/users" to listOf(RequestMethod.GET))
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        val activeChildren = root.menuNavigations.filter { it.status }
+        activeChildren.size shouldBe 1
+        activeChildren.none { it === expiredUsersNode } shouldBe true
+        expiredUsersNode.status shouldBe false
+    }
+
+    @Test
+    fun `spec과 기존 트리가 동일하면 변경이 없다`() {
+        val openAPI = buildOpenAPI("/users" to listOf(RequestMethod.GET, RequestMethod.POST))
+
+        // 첫 번째 sync로 초기 트리 생성
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+        io.mockk.clearMocks(repo, answers = false, recordedCalls = true)
+        every { repo.save(any()) } returns MenuNavigation.root()
+
+        // 동일한 spec으로 재실행 — save 호출 없어야 함
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        verify(exactly = 0) { repo.save(any()) }
+    }
+
+    @Test
+    fun `기존 트리가 없는 상태에서 spec을 적용하면 트리가 신규 생성된다`() {
+        val openAPI =
+            buildOpenAPI(
+                "/users/:id" to listOf(RequestMethod.GET, RequestMethod.POST),
+                "/orders" to listOf(RequestMethod.GET),
+            )
+
+        TreeBaseSyncToMenu(openAPI, root).makeTree(repo)
+
+        // /users(GET), /orders(GET) 두 개가 root 자식으로 생성
+        val rootChildren = root.menuNavigations.filter { it.status }
+        rootChildren.size shouldBe 2
+        rootChildren.any { it.uriBlock == "/users" } shouldBe true
+        rootChildren.any { it.uriBlock == "/orders" } shouldBe true
+    }
+
+    // --- helpers ---
+
+    private fun setupTree(vararg specs: HttpAPISpec) {
+        TreeBasePathToMenu(specs.toList(), root).makeTree(repo)
+    }
+
+    private fun buildOpenAPI(vararg pathAndMethods: Pair<String, List<RequestMethod>>): OpenAPI {
+        val paths = Paths()
+        for ((url, methods) in pathAndMethods) {
+            val pathItem = PathItem().summary(url)
+            for (method in methods) {
+                val op = Operation()
+                when (method) {
+                    RequestMethod.GET -> {
+                        pathItem.get(op)
+                    }
+
+                    RequestMethod.POST -> {
+                        pathItem.post(op)
+                    }
+
+                    RequestMethod.PUT -> {
+                        pathItem.put(op)
+                    }
+
+                    RequestMethod.DELETE -> {
+                        pathItem.delete(op)
+                    }
+
+                    RequestMethod.PATCH -> {
+                        pathItem.patch(op)
+                    }
+
+                    else -> {}
+                }
+            }
+            paths.addPathItem(url, pathItem)
+        }
+        return OpenAPI().paths(paths)
+    }
+}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLockAspectTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/config/redis/distributedlock/DistributedLockAspectTest.kt
@@ -1,0 +1,95 @@
+package io.mustelidae.otter.lutrogale.config.redis.distributedlock
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.aspectj.lang.ProceedingJoinPoint
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import java.util.concurrent.TimeUnit
+
+class DistributedLockAspectTest {
+    private lateinit var redisTemplate: StringRedisTemplate
+    private lateinit var valueOps: ValueOperations<String, String>
+    private lateinit var pjp: ProceedingJoinPoint
+    private lateinit var aspect: DistributedLockAspect
+    private lateinit var lock: DistributedLock
+
+    @BeforeEach
+    fun setUp() {
+        redisTemplate = mockk()
+        valueOps = mockk()
+        pjp = mockk()
+        aspect = DistributedLockAspect(redisTemplate)
+        lock = mockk()
+
+        every { redisTemplate.opsForValue() } returns valueOps
+        every { lock.qualifier } returns "test-qualifier"
+        every { lock.leaseTime } returns 10L
+        every { lock.timeUnit } returns TimeUnit.MINUTES
+    }
+
+    @Test
+    fun `락 획득 성공 시 proceed가 실행되고 결과를 반환한다`() {
+        every { valueOps.setIfAbsent(any(), any(), any()) } returns true
+        every { redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), any()) } returns 1L
+        every { pjp.proceed() } returns "result"
+
+        val result = aspect.around(pjp, lock)
+
+        result shouldBe "result"
+        verify(exactly = 1) { pjp.proceed() }
+        verify(exactly = 1) { redisTemplate.execute(any(), any<List<String>>(), any()) }
+    }
+
+    @Test
+    fun `락 획득 실패 시 proceed가 실행되지 않고 null을 반환한다`() {
+        every { valueOps.setIfAbsent(any(), any(), any()) } returns false
+
+        val result = aspect.around(pjp, lock)
+
+        result shouldBe null
+        verify(exactly = 0) { pjp.proceed() }
+    }
+
+    @Test
+    fun `Redis 연결 실패 시 fail-open으로 proceed가 실행된다`() {
+        every { valueOps.setIfAbsent(any(), any(), any()) } throws RuntimeException("Redis connection failed")
+        every { pjp.proceed() } returns "fallback-result"
+
+        val result = aspect.around(pjp, lock)
+
+        result shouldBe "fallback-result"
+        verify(exactly = 1) { pjp.proceed() }
+    }
+
+    @Test
+    fun `proceed에서 예외가 발생해도 finally에서 동일한 lock value로 unlock이 실행된다`() {
+        val setValueSlot = slot<String>()
+        val executeArgSlot = slot<String>()
+        every { valueOps.setIfAbsent(any(), capture(setValueSlot), any()) } returns true
+        every { redisTemplate.execute(any<DefaultRedisScript<Long>>(), any<List<String>>(), capture(executeArgSlot)) } returns 1L
+        every { pjp.proceed() } throws RuntimeException("business logic failed")
+
+        assertThrows<RuntimeException> { aspect.around(pjp, lock) }
+
+        verify(exactly = 1) { redisTemplate.execute(any(), any<List<String>>(), any()) }
+        executeArgSlot.captured shouldBe setValueSlot.captured
+    }
+
+    @Test
+    fun `qualifier로 올바른 Redis key가 생성된다`() {
+        val capturedKey = slot<String>()
+        every { valueOps.setIfAbsent(capture(capturedKey), any(), any()) } returns false
+
+        aspect.around(pjp, lock)
+
+        capturedKey.captured shouldBe "lutrogale:distributed-lock:test-qualifier"
+    }
+}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/ProjectTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/ProjectTest.kt
@@ -2,4 +2,5 @@ package io.mustelidae.otter.lutrogale.web.domain.project
 
 class ProjectTest
 
-fun Project.Companion.aFixture(apiKey: String): Project = Project("Sample", null, apiKey)
+fun Project.Companion.aFixture(apiKey: String): Project =
+    Project("Sample", null, apiKey, io.mustelidae.otter.lutrogale.web.domain.navigation.MenuNavigation.ListStructure.FLAT)

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectControllerFlow.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectControllerFlow.kt
@@ -1,0 +1,100 @@
+package io.mustelidae.otter.lutrogale.web.domain.project.api
+
+import io.mustelidae.otter.lutrogale.common.Replies
+import io.mustelidae.otter.lutrogale.common.Reply
+import io.mustelidae.otter.lutrogale.utils.fromJson
+import io.mustelidae.otter.lutrogale.utils.toJson
+import jakarta.servlet.http.Cookie
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActionsDsl
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+
+internal class ProjectControllerFlow(
+    private val mockMvc: MockMvc,
+) {
+    fun findAll(session: Cookie): List<ProjectResources.Reply> =
+        mockMvc
+            .get("/v1/maintenance/projects") {
+                contentType = MediaType.APPLICATION_JSON
+                cookie(session)
+            }.andExpect {
+                status { isOk() }
+            }.andReturn()
+            .response
+            .contentAsString
+            .fromJson<Replies<ProjectResources.Reply>>()
+            .getContent()
+            .toList()
+
+    fun getSyncInfo(
+        session: Cookie,
+        projectId: Long,
+    ): ProjectResources.Reply.SyncInfo =
+        mockMvc
+            .get("/v1/maintenance/project/$projectId/sync") {
+                contentType = MediaType.APPLICATION_JSON
+                cookie(session)
+            }.andExpect {
+                status { isOk() }
+            }.andReturn()
+            .response
+            .contentAsString
+            .fromJson<Reply<ProjectResources.Reply.SyncInfo>>()
+            .content!!
+
+    fun getSyncInfoExpectStatus(
+        session: Cookie,
+        projectId: Long,
+    ): ResultActionsDsl =
+        mockMvc.get("/v1/maintenance/project/$projectId/sync") {
+            contentType = MediaType.APPLICATION_JSON
+            cookie(session)
+        }
+
+    fun registerSync(
+        session: Cookie,
+        projectId: Long,
+        request: ProjectResources.Request.RegisterSync,
+    ) {
+        mockMvc
+            .post("/v1/maintenance/project/$projectId/sync") {
+                contentType = MediaType.APPLICATION_JSON
+                cookie(session)
+                content = request.toJson()
+            }.andExpect {
+                status { isCreated() }
+            }
+    }
+
+    fun updateSync(
+        session: Cookie,
+        projectId: Long,
+        request: ProjectResources.Modify.UpdateSync,
+    ) {
+        mockMvc
+            .put("/v1/maintenance/project/$projectId/sync") {
+                contentType = MediaType.APPLICATION_JSON
+                cookie(session)
+                content = request.toJson()
+            }.andExpect {
+                status { isOk() }
+            }
+    }
+
+    fun deleteSync(
+        session: Cookie,
+        projectId: Long,
+    ) {
+        mockMvc
+            .delete("/v1/maintenance/project/$projectId/sync") {
+                contentType = MediaType.APPLICATION_JSON
+                cookie(session)
+            }.andExpect {
+                status { isNoContent() }
+            }
+    }
+}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectSyncTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/web/domain/project/api/ProjectSyncTest.kt
@@ -1,0 +1,142 @@
+package io.mustelidae.otter.lutrogale.web.domain.project.api
+
+import io.kotest.matchers.shouldBe
+import io.mustelidae.otter.lutrogale.api.config.FlowTestSupport
+import io.mustelidae.otter.lutrogale.utils.toJson
+import io.mustelidae.otter.lutrogale.web.domain.admin.api.AdminManagementControllerFlow
+import io.mustelidae.otter.lutrogale.web.domain.project.Project
+import io.mustelidae.otter.lutrogale.web.domain.project.ProjectInteraction
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.post
+
+internal class ProjectSyncTest : FlowTestSupport() {
+    @Autowired
+    private lateinit var projectInteraction: ProjectInteraction
+
+    private lateinit var adminFlow: AdminManagementControllerFlow
+    private lateinit var flow: ProjectControllerFlow
+    private lateinit var superSession: Cookie
+    private var testProjectId: Long = 0L
+
+    @BeforeEach
+    fun setUp() {
+        adminFlow = AdminManagementControllerFlow(mockMvc)
+        flow = ProjectControllerFlow(mockMvc)
+        superSession = adminFlow.login("admin@osori.com", "admin")
+        testProjectId = projectInteraction.register("Sync Test Project", "for sync testing", null)
+    }
+
+    @Test
+    fun `자동 Sync를 등록하면 조회 시 동일한 specType과 url을 반환한다`() {
+        val request =
+            ProjectResources.Request.RegisterSync(
+                specType = Project.SpecType.OPENAPI_JSON,
+                url = "http://example.com/openapi.json",
+            )
+        flow.registerSync(superSession, testProjectId, request)
+
+        val syncInfo = flow.getSyncInfo(superSession, testProjectId)
+        syncInfo.specType shouldBe Project.SpecType.OPENAPI_JSON
+        syncInfo.url shouldBe "http://example.com/openapi.json"
+    }
+
+    @Test
+    fun `자동 Sync를 업데이트하면 조회 시 변경된 정보를 반환한다`() {
+        flow.registerSync(
+            superSession,
+            testProjectId,
+            ProjectResources.Request.RegisterSync(
+                specType = Project.SpecType.OPENAPI_JSON,
+                url = "http://example.com/v1.json",
+            ),
+        )
+
+        flow.updateSync(
+            superSession,
+            testProjectId,
+            ProjectResources.Modify.UpdateSync(
+                specType = Project.SpecType.OPENAPI_YAML,
+                url = "http://example.com/v2.yaml",
+            ),
+        )
+
+        val syncInfo = flow.getSyncInfo(superSession, testProjectId)
+        syncInfo.specType shouldBe Project.SpecType.OPENAPI_YAML
+        syncInfo.url shouldBe "http://example.com/v2.yaml"
+    }
+
+    @Test
+    fun `자동 Sync를 삭제하면 조회 시 404가 반환된다`() {
+        flow.registerSync(
+            superSession,
+            testProjectId,
+            ProjectResources.Request.RegisterSync(
+                specType = Project.SpecType.GRAPHQL,
+                url = "http://example.com/graphql",
+            ),
+        )
+        flow.deleteSync(superSession, testProjectId)
+
+        flow
+            .getSyncInfoExpectStatus(superSession, testProjectId)
+            .andExpect { status { isNotFound() } }
+    }
+
+    @Test
+    fun `Sync가 등록된 프로젝트는 전체 조회 시 syncEnabled가 true이다`() {
+        flow.registerSync(
+            superSession,
+            testProjectId,
+            ProjectResources.Request.RegisterSync(
+                specType = Project.SpecType.OPENAPI_JSON,
+                url = "http://example.com/openapi.json",
+            ),
+        )
+
+        val projects = flow.findAll(superSession)
+        val project = projects.first { it.id == testProjectId }
+        project.syncEnabled shouldBe true
+        project.specType shouldBe Project.SpecType.OPENAPI_JSON
+        project.migrationUrl shouldBe "http://example.com/openapi.json"
+    }
+
+    @Test
+    fun `Sync가 없는 프로젝트는 전체 조회 시 syncEnabled가 false이다`() {
+        val projects = flow.findAll(superSession)
+        val project = projects.first { it.id == testProjectId }
+        project.syncEnabled shouldBe false
+    }
+
+    @Test
+    fun `이미 Sync가 등록된 프로젝트에 등록 시도하면 412가 반환된다`() {
+        flow.registerSync(
+            superSession,
+            testProjectId,
+            ProjectResources.Request.RegisterSync(
+                specType = Project.SpecType.OPENAPI_JSON,
+                url = "http://example.com/openapi.json",
+            ),
+        )
+
+        mockMvc
+            .post("/v1/maintenance/project/$testProjectId/sync") {
+                contentType = MediaType.APPLICATION_JSON
+                cookie(superSession)
+                content =
+                    ProjectResources.Request
+                        .RegisterSync(
+                            specType = Project.SpecType.OPENAPI_JSON,
+                            url = "http://example.com/duplicate.json",
+                        ).toJson()
+            }.andExpect { status { isPreconditionFailed() } }
+    }
+
+    @Test
+    fun `Sync가 없는 프로젝트에 DELETE 요청하면 204가 반환된다`() {
+        flow.deleteSync(superSession, testProjectId)
+    }
+}


### PR DESCRIPTION
## Summary

- **Project sync CRUD API**: `GET/POST/PUT/DELETE /v1/maintenance/project/{id}/sync` for managing per-project migration spec URL configuration
- **Dashboard UI**: "자동Sync 추가" button (btn-primary) on unregistered projects → Bootstrap modal with specType selector, URL input, preview test, and save; "자동 Sync" button (btn-success) on registered projects → edit modal with update + delete actions
- **Sync engine**: `FlatBaseSyncToMenu`, `TreeBaseSyncToMenu` (OpenAPI), `FlatBaseGraphQLSyncToMenu` (GraphQL) — diffs existing `MenuNavigation` tree against incoming spec; creates new nodes and soft-expires removed ones
- **Distributed lock**: `@DistributedLock` AOP annotation backed by Redis `SET NX PX` acquire + Lua atomic release; fail-open on Redis error
- **Scheduler**: `ProjectSpecSyncScheduler` runs every 5 minutes with `@DistributedLock(qualifier = "project-spec-sync")` to prevent duplicate execution across instances

## Key design decisions

- `registerSyncSpec()` guards against duplicate registration (returns 412 if sync already enabled); `startSyncSpec()` used for PUT updates only
- `SyncInfo.from()` uses `!!` only — layer responsibility kept clean; `DataNotFindException` thrown in Controller
- Distributed lock: fail-open policy ensures sync continues even when Redis is unavailable; UUID-based lock value prevents cross-instance accidental release

## Test plan

- [x] `FlatBaseSyncToMenuTest` — diff/create/expire rules for flat OpenAPI sync
- [x] `TreeBaseSyncToMenuTest` — tree-structured sync rules
- [x] `DistributedLockAspectTest` — 5 MockK unit tests (acquire success, contention skip, fail-open, finally unlock, key format)
- [x] `ProjectSyncTest` — 7 integration tests: CRUD round-trip, duplicate registration 412, delete then 404, syncEnabled field in list response
- [x] `dashboard-sync.spec.ts` — 8 Playwright e2e tests: button render, modal structure, specType default, register→edit button swap, edit modal prefill, update reflected, delete→restore