### PR TITLE
chore: release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 [![Build Status](https://github.com/stray-cat-developers/lutrogale-otter/actions/workflows/gradle.yml/badge.svg)](https://github.com/stray-cat-developers/lutrogale-otter)
 
 ## New Features!
+### 1.1.0
+
+- **관리자 계정 관리**: SUPER 관리자가 관리자 계정을 목록 조회, 생성, 만료, 비밀번호 변경할 수 있습니다.
+- **사용자 일괄 등록**: SUPER 관리자가 CSV 형식으로 다수의 사용자를 한 번에 등록할 수 있습니다.
+- **권한 감사 로그**: 권한 체크 결과를 Grafana/Loki 파이프라인으로 전송하여 감사 로그를 기록합니다.
+- **마이그레이션 스펙 URL 자동 동기화**: 등록된 OpenAPI/GraphQL 스펙 URL을 주기적으로 자동 동기화하여 MenuNavigation 트리를 최신 상태로 유지합니다.
+  - 대시보드에서 프로젝트별 동기화 상태를 확인하고 수동 동기화를 실행할 수 있습니다.
+- **이메일 기반 사용자 만료 API**: 이메일 주소로 특정 사용자를 만료(EXPIRE) 상태로 일괄 처리하는 API를 추가했습니다.
+- **보안 강화**: 관리자 비밀번호 해싱 알고리즘을 SHA-256에서 BCrypt로 교체했습니다.
+- **라이브러리 업그레이드**: Spring Boot, Kotlin, QueryDSL 등 주요 라이브러리를 최신 안정 버전으로 업그레이드했습니다.
+
 ### 1.0.3
 
 - 권한 체크 결과를 Redis에 5분간 캐싱하여 동일 요청에 대한 DB 조회를 줄입니다.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "io.mustelidae.otter.lutrogale"
-version = "1.0.3"
+version = "1.1.0"
 
 kotlin {
     jvmToolchain(21)

--- a/src/main/resources/templates/layout/footer.ftl
+++ b/src/main/resources/templates/layout/footer.ftl
@@ -2,7 +2,7 @@
 <footer class="main-footer">
     <div class="pull-right hidden-xs">
         <a href="/swagger-ui.html" target="_blank" title="API Docs"><i class="fa fa-book"></i></a>
-        &nbsp;<b>Version</b> 1.0.3
+        &nbsp;<b>Version</b> 1.1.0
     </div>
     <strong>Copyright &copy; 2016 - 2024 <a href="https://github.com/stray-cat-developers/lutrogale-otter"></a>Stray cat developers</strong> All rights
     reserved.


### PR DESCRIPTION
## Summary

- `build.gradle.kts` 버전을 `1.0.3` → `1.1.0`으로 변경
- HTML footer 표시 버전을 `1.1.0`으로 변경
- `README.md`에 1.1.0 릴리즈 노트 추가

## 1.1.0 변경 사항

| 카테고리 | 내용 | PR |
|---|---|---|
| feat | 관리자 계정 관리 (목록 조회, 생성, 만료, 비밀번호 변경) | #14 |
| feat | 사용자 일괄 등록 (SUPER admin) | #17 |
| feat | 권한 체크 감사 로그 Grafana/Loki 연동 | #16 |
| feat | 마이그레이션 스펙 URL 자동 동기화 관리 | #22 |
| feat | 이메일 기반 사용자 만료 API | #23 |
| fix | 관리자 비밀번호 해싱 SHA-256 → BCrypt 교체 | #15 |
| chore | Spring Boot, Kotlin 등 주요 라이브러리 최신 안정 버전 업그레이드 | #18, #19 |

## Test plan

- [ ] `./gradlew build` 정상 빌드 확인
- [ ] README.md `### 1.1.0` 섹션 내용 육안 확인
- [ ] 앱 기동 후 footer에 `Version 1.1.0` 표시 확인