### PR TITLE
test: replace Testcontainers Redis with jedis-mock

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,26 +74,12 @@ dependencies {
 
     implementation("org.springframework.security:spring-security-crypto")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
-    testImplementation("org.springframework.boot:spring-boot-testcontainers")
-    testImplementation("org.testcontainers:testcontainers")
-    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("com.github.fppt:jedis-mock:1.1.14")
 }
 
 tasks.getByName<Test>("test") {
     jvmArgs("-XX:+EnableDynamicAgentLoading") // https://github.com/mockito/mockito/issues/3037
     useJUnitPlatform()
-
-    // Testcontainers: Rancher Desktop 소켓이 있으면 DOCKER_HOST 자동 설정 및 Ryuk 비활성화
-    val rdSock = file("${System.getProperty("user.home")}/.rd/docker.sock")
-    if (rdSock.exists()) {
-        if (System.getenv("DOCKER_HOST") == null) {
-            environment("DOCKER_HOST", "unix://${rdSock.absolutePath}")
-        }
-        // Rancher Desktop은 Ryuk(socket mount)를 지원하지 않으므로 비활성화
-        if (System.getenv("TESTCONTAINERS_RYUK_DISABLED") == null) {
-            environment("TESTCONTAINERS_RYUK_DISABLED", "true")
-        }
-    }
 
     addTestListener(object : TestListener {
         override fun beforeSuite(suite: TestDescriptor) {}

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/config/TestRedisConfiguration.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/config/TestRedisConfiguration.kt
@@ -1,16 +1,19 @@
 package io.mustelidae.otter.lutrogale.config
 
+import com.github.fppt.jedismock.RedisServer
 import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.context.annotation.Bean
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.utility.DockerImageName
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 
 @TestConfiguration(proxyBeanMethods = false)
 class TestRedisConfiguration {
+    @Bean(destroyMethod = "stop")
+    fun redisServer(): RedisServer = RedisServer.newRedisServer().start()
+
     @Bean
-    @ServiceConnection(name = "redis")
-    fun redisContainer(): GenericContainer<*> =
-        GenericContainer(DockerImageName.parse("redis:7.2-alpine"))
-            .withExposedPorts(6379)
+    @Primary
+    fun redisConnectionFactory(redisServer: RedisServer): LettuceConnectionFactory =
+        LettuceConnectionFactory(RedisStandaloneConfiguration(redisServer.host, redisServer.bindPort))
 }


### PR DESCRIPTION
## Summary

- Testcontainers 기반 Redis 컨테이너를 `jedis-mock` (순수 JVM Redis 에뮬레이션)으로 교체
- Docker 데몬 없이 테스트 실행 가능 — GitHub Actions CI 및 Docker 없는 로컬 환경 모두 대응
- `spring-boot-testcontainers`, `testcontainers`, `junit-jupiter` 의존성 3개 제거 → `jedis-mock:1.1.14` 단일 의존성으로 대체
- Rancher Desktop 소켓 감지 로직(`build.gradle.kts`) 불필요하여 함께 제거

## Test plan

- [ ] `./gradlew test` — 97개 테스트 통과 (Docker 없이)
- [ ] GitHub Actions CI 빌드 통과 확인