### PR TITLE
feat: derive app version from build.gradle.kts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ COPY . .
 RUN ./gradlew clean build
 
 FROM eclipse-temurin:21-jdk-alpine as runner
-COPY --from=builder /app/build/libs/lutrogale-1.0.2.jar lutrogale-1.0.2.jar
-ENTRYPOINT [ "java", "-jar", "lutrogale-1.0.2.jar" ]
+COPY --from=builder /app/build/libs/lutrogale-*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,10 @@ dependencies {
     testImplementation("com.github.fppt:jedis-mock:1.1.14")
 }
 
+springBoot {
+    buildInfo()
+}
+
 tasks.getByName<Test>("test") {
     jvmArgs("-XX:+EnableDynamicAgentLoading") // https://github.com/mockito/mockito/issues/3037
     useJUnitPlatform()

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdvice.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdvice.kt
@@ -1,0 +1,13 @@
+package io.mustelidae.otter.lutrogale.config
+
+import org.springframework.boot.info.BuildProperties
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ModelAttribute
+
+@ControllerAdvice(basePackages = ["io.mustelidae.otter.lutrogale.web"])
+class WebViewAdvice(
+    private val buildProperties: BuildProperties,
+) {
+    @ModelAttribute("appVersion")
+    fun appVersion(): String = buildProperties.version
+}

--- a/src/main/resources/templates/layout/footer.ftl
+++ b/src/main/resources/templates/layout/footer.ftl
@@ -2,7 +2,7 @@
 <footer class="main-footer">
     <div class="pull-right hidden-xs">
         <a href="/swagger-ui.html" target="_blank" title="API Docs"><i class="fa fa-book"></i></a>
-        &nbsp;<b>Version</b> 1.1.0
+        &nbsp;<b>Version</b> ${appVersion!'unknown'}
     </div>
     <strong>Copyright &copy; 2016 - 2024 <a href="https://github.com/stray-cat-developers/lutrogale-otter"></a>Stray cat developers</strong> All rights
     reserved.

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdviceTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdviceTest.kt
@@ -1,0 +1,16 @@
+package io.mustelidae.otter.lutrogale.config
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.info.BuildProperties
+import java.util.Properties
+
+class WebViewAdviceTest :
+    StringSpec({
+        "BuildProperties의 version을 appVersion 모델 속성으로 반환한다" {
+            val props = Properties().apply { setProperty("version", "1.1.0") }
+            val advice = WebViewAdvice(BuildProperties(props))
+
+            advice.appVersion() shouldBe "1.1.0"
+        }
+    })


### PR DESCRIPTION
## Summary

- `build.gradle.kts`의 `version` 한 곳만 수정하면 footer UI와 Dockerfile 빌드 버전까지 자동으로 반영되도록 변경
- `springBoot { buildInfo() }`로 빌드 시 `META-INF/build-info.properties` 생성 → Spring Boot가 `BuildProperties` 빈을 자동 등록
- `WebViewAdvice`(`@ControllerAdvice`, web 패키지 한정)에서 버전을 읽어 Freemarker 모델에 `appVersion`으로 주입
- `footer.ftl` 하드코딩 제거, Dockerfile runner 스테이지 JAR 이름 와일드카드 처리

## Test plan

- [ ] `WebViewAdviceTest` 단위 테스트 통과 확인
- [ ] 전체 테스트 98개 통과 확인 (로컬 검증 완료)
- [ ] `build.gradle.kts`의 `version` 값 변경 시 footer에 반영되는지 앱 실행으로 확인