### PR TITLE
feat: derive app version from build.gradle.kts for footer and Dockerf…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ COPY . .
 RUN ./gradlew clean build
 
 FROM eclipse-temurin:21-jdk-alpine as runner
-COPY --from=builder /app/build/libs/lutrogale-1.0.2.jar lutrogale-1.0.2.jar
-ENTRYPOINT [ "java", "-jar", "lutrogale-1.0.2.jar" ]
+COPY --from=builder /app/build/libs/lutrogale-*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,10 @@ dependencies {
     testImplementation("com.github.fppt:jedis-mock:1.1.14")
 }
 
+springBoot {
+    buildInfo()
+}
+
 tasks.getByName<Test>("test") {
     jvmArgs("-XX:+EnableDynamicAgentLoading") // https://github.com/mockito/mockito/issues/3037
     useJUnitPlatform()

--- a/src/main/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdvice.kt
+++ b/src/main/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdvice.kt
@@ -1,0 +1,13 @@
+package io.mustelidae.otter.lutrogale.config
+
+import org.springframework.boot.info.BuildProperties
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ModelAttribute
+
+@ControllerAdvice(basePackages = ["io.mustelidae.otter.lutrogale.web"])
+class WebViewAdvice(
+    private val buildProperties: BuildProperties,
+) {
+    @ModelAttribute("appVersion")
+    fun appVersion(): String = buildProperties.version
+}

--- a/src/main/resources/templates/layout/footer.ftl
+++ b/src/main/resources/templates/layout/footer.ftl
@@ -2,7 +2,7 @@
 <footer class="main-footer">
     <div class="pull-right hidden-xs">
         <a href="/swagger-ui.html" target="_blank" title="API Docs"><i class="fa fa-book"></i></a>
-        &nbsp;<b>Version</b> 1.1.0
+        &nbsp;<b>Version</b> ${appVersion!'unknown'}
     </div>
     <strong>Copyright &copy; 2016 - 2024 <a href="https://github.com/stray-cat-developers/lutrogale-otter"></a>Stray cat developers</strong> All rights
     reserved.

--- a/src/test/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdviceTest.kt
+++ b/src/test/kotlin/io/mustelidae/otter/lutrogale/config/WebViewAdviceTest.kt
@@ -1,0 +1,16 @@
+package io.mustelidae.otter.lutrogale.config
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.info.BuildProperties
+import java.util.Properties
+
+class WebViewAdviceTest :
+    StringSpec({
+        "BuildProperties의 version을 appVersion 모델 속성으로 반환한다" {
+            val props = Properties().apply { setProperty("version", "1.1.0") }
+            val advice = WebViewAdvice(BuildProperties(props))
+
+            advice.appVersion() shouldBe "1.1.0"
+        }
+    })


### PR DESCRIPTION
…ile (#26)

- Add springBoot { buildInfo() } to generate META-INF/build-info.properties at build time
- Add WebViewAdvice to inject BuildProperties.version as appVersion model attribute (scoped to web package only)
- Replace hardcoded version in footer.ftl with ${appVersion!'unknown'} Freemarker variable
- Replace hardcoded JAR name in Dockerfile runner stage with wildcard lutrogale-*.jar